### PR TITLE
feat: Revised field names and docs on layer4

### DIFF
--- a/layer4/assessment_test.go
+++ b/layer4/assessment_test.go
@@ -119,8 +119,8 @@ func TestRun(t *testing.T) {
 			if result != a.Result {
 				t.Errorf("expected match between Run return value (%s) and assessment Result value (%s)", result, data.expectedResult)
 			}
-			if a.Steps_Executed != data.numberOfStepsToRun {
-				t.Errorf("expected to run %d tests, got %d", data.numberOfStepsToRun, a.Steps_Executed)
+			if a.StepsExecuted != data.numberOfStepsToRun {
+				t.Errorf("expected to run %d tests, got %d", data.numberOfStepsToRun, a.StepsExecuted)
 			}
 		})
 	}
@@ -130,8 +130,8 @@ func TestRunB(t *testing.T) {
 	for _, data := range getAssessmentsTestData() {
 		t.Run(data.testName+"-no-changes", func(t *testing.T) {
 			data.assessment.Run(nil, false)
-			if data.assessment.Steps_Executed != data.numberOfStepsToRun {
-				t.Errorf("expected to run %d tests, got %d", data.numberOfStepsToRun, data.assessment.Steps_Executed)
+			if data.assessment.StepsExecuted != data.numberOfStepsToRun {
+				t.Errorf("expected to run %d tests, got %d", data.numberOfStepsToRun, data.assessment.StepsExecuted)
 			}
 			for _, change := range data.assessment.Changes {
 				if change.Allowed {

--- a/layer4/change.go
+++ b/layer4/change.go
@@ -4,28 +4,41 @@ import (
 	"fmt"
 )
 
+// Prepared function to apply the change
 type ApplyFunc func(interface{}) (interface{}, error)
+
+// Prepared function to revert the change after it has been applied
 type RevertFunc func(interface{}) error
 
 // Change is a struct that contains the data and functions associated with a single change to a target resource.
 type Change struct {
-	Target_Name string     // Required. TargetName is the name or ID of the resource or configuration that is to be changed
-	Description string     // Required. Description is a human-readable description of the change
-	applyFunc   ApplyFunc  // Required. applyFunc is the function that will be executed to make the change
-	revertFunc  RevertFunc // Required. revertFunc is the function that will be executed to undo the change
-
-	Target_Object interface{} // TargetObject is supplemental data describing the object that was changed
-	Applied       bool        // Applied is true if the change was successfully applied at least once
-	Reverted      bool        // Reverted is true if the change was successfully reverted and not applied again
-	Error         error       // Error is used if any error occurred during the change
-	Allowed       bool        // Allowed may be disabled to prevent the change from being applied
+	// TargetName is the name or ID of the resource or configuration that is to be changed
+	TargetName string `yaml:"target-name"`
+	// Description is a human-readable description of the change
+	Description string `yaml:"description"`
+	// applyFunc is the function that will be executed to make the change
+	applyFunc ApplyFunc
+	// revertFunc is the function that will be executed to undo the change
+	revertFunc RevertFunc
+	// TargetObject is supplemental data describing the object that was changed
+	TargetObject interface{} `yaml:"target-object,omitempty"`
+	// Applied is true if the change was successfully applied at least once
+	Applied bool `yaml:"applied,omitempty"`
+	// Reverted is true if the change was successfully reverted and not applied again
+	Reverted bool `yaml:"reverted,omitempty"`
+	// Error is used if any error occurred during the change
+	Error error `yaml:"error,omitempty"`
+	// Allowed may be disabled to prevent the change from being applied
+	Allowed bool `yaml:"allowed,omitempty"`
 }
 
+// Allow marks the change as allowed to be applied.
 func (c *Change) Allow() {
 	c.Allowed = true
 }
 
-// Apply executes the Apply function for the change
+// Apply the prepared function for the change. It will not apply the change if it has already been applied and not reverted.
+// It will also not apply the change if it is not allowed.
 func (c *Change) Apply(targetName string, targetObject interface{}, changeInput interface{}) (applied bool, changeOutput interface{}) {
 	if !c.Allowed {
 		return
@@ -39,8 +52,8 @@ func (c *Change) Apply(targetName string, targetObject interface{}, changeInput 
 	if c.Applied && !c.Reverted {
 		return true, nil
 	}
-	c.Target_Name = targetName
-	c.Target_Object = targetObject
+	c.TargetName = targetName
+	c.TargetObject = targetObject
 	changeOutput, err = c.applyFunc(changeInput)
 	if err != nil {
 		return false, changeOutput
@@ -50,14 +63,13 @@ func (c *Change) Apply(targetName string, targetObject interface{}, changeInput 
 	return true, changeOutput
 }
 
-// Revert executes the Revert function for the change
+// Revert the change by executing the revert function. It will not revert the change if it has not been applied.
 func (c *Change) Revert(data interface{}) {
 	err := c.precheck()
 	if err != nil {
 		c.Error = err
 		return
 	}
-	// Do nothing if the change has not been applied
 	if !c.Applied {
 		return
 	}
@@ -69,15 +81,16 @@ func (c *Change) Revert(data interface{}) {
 	c.Reverted = true
 }
 
-// precheck verifies that the applyFunc and revertFunc are defined for the change
+// precheck verifies that the applyFunc and revertFunc are defined for the change.
+// It returns an error if the change is not valid.
 func (c *Change) precheck() error {
 	if c.applyFunc == nil || c.revertFunc == nil {
 		return fmt.Errorf("applyFunc and revertFunc must be defined for a change, but got applyFunc: %v, revertFunc: %v",
 			c.applyFunc != nil, c.revertFunc != nil)
 	}
-	if c.Target_Name == "" || c.Description == "" {
+	if c.TargetName == "" || c.Description == "" {
 		return fmt.Errorf("change must have a TargetName and Description defined, but got TargetName: %v, Description: %v",
-			c.Target_Name, c.Description)
+			c.TargetName, c.Description)
 	}
 	if c.Error != nil {
 		return fmt.Errorf("change has a previous error and can no longer be applied: %s", c.Error.Error())
@@ -85,13 +98,13 @@ func (c *Change) precheck() error {
 	return nil
 }
 
-// NewChange creates a new Change object and adds it to the Assessment
+// NewChange creates a new Change object.
 func NewChange(targetName string, description string, targetObject interface{}, applyFunc ApplyFunc, revertFunc RevertFunc) Change {
 	return Change{
-		Target_Name:   targetName,
-		Target_Object: targetObject,
-		Description:   description,
-		applyFunc:     applyFunc,
-		revertFunc:    revertFunc,
+		TargetName:   targetName,
+		TargetObject: targetObject,
+		Description:  description,
+		applyFunc:    applyFunc,
+		revertFunc:   revertFunc,
 	}
 }

--- a/layer4/control_evaluation.go
+++ b/layer4/control_evaluation.go
@@ -7,17 +7,25 @@ import (
 	"syscall"
 )
 
-// ControlEvaluation is a struct that contains all assessment results, organized by name
+// ControlEvaluation is a struct that contains all assessment results, organized by name.
 type ControlEvaluation struct {
-	Name              string        // Name is the name of the control being evaluated
-	Control_Id        string        // Control_Id is the unique identifier for the control being evaluated
-	Result            Result        // Result is the overall result of the control evaluation
-	Message           string        // Message is the human-readable result of the final assessment to run in this evaluation
-	Corrupted_State   bool          // Corrupted_State is true if the control evaluation was interrupted and changes were not reverted
-	Remediation_Guide string        // Remediation_Guide is the URL to the documentation for this evaluation
-	Assessments       []*Assessment // Assessments is a map of pointers to Assessment objects to establish idempotency
+	// Name is the name of the control being evaluated
+	Name string `yaml:"name"`
+	// ControlID is the unique identifier for the control being evaluated
+	ControlID string `yaml:"control-id"`
+	// Result is the overall result of the control evaluation
+	Result Result `yaml:"result"`
+	// Message is the human-readable result of the final assessment to run in this evaluation
+	Message string `yaml:"message"`
+	// CorruptedState is true if the control evaluation was interrupted and changes were not reverted
+	CorruptedState bool `yaml:"corrupted-state"`
+	// RemediationGuide is the URL to the documentation for this evaluation
+	RemediationGuide string `yaml:"remediation-guide"`
+	// Assessments is a map of pointers to Assessment objects to establish idempotency
+	Assessments []*Assessment `yaml:"assessments"`
 }
 
+// AddAssessment creates a new Assessment object and adds it to the ControlEvaluation.
 func (c *ControlEvaluation) AddAssessment(requirementId string, description string, applicability []string, steps []AssessmentStep) (assessment *Assessment) {
 	assessment, err := NewAssessment(requirementId, description, applicability, steps)
 	if err != nil {
@@ -29,10 +37,9 @@ func (c *ControlEvaluation) AddAssessment(requirementId string, description stri
 }
 
 // Evaluate runs each step in each assessment, updating the relevant fields on the control evaluation.
-// It will halt if a step returns a failed result.
-// `targetData` is the data that the assessment will be run against.
-// `userApplicability` is a slice of strings that determine when the assessment is applicable.
-// `changesAllowed` determines whether the assessment is allowed to execute its changes.
+// It will halt if a step returns a failed result. The targetData is the data that the assessment will be run against.
+// The userApplicability is a slice of strings that determine when the assessment is applicable. The changesAllowed
+// determines whether the assessment is allowed to execute its changes.
 func (c *ControlEvaluation) Evaluate(targetData interface{}, userApplicability []string, changesAllowed bool) {
 	if len(c.Assessments) == 0 {
 		c.Result = NeedsReview
@@ -61,21 +68,19 @@ func (c *ControlEvaluation) Evaluate(targetData interface{}, userApplicability [
 	c.Cleanup()
 }
 
+// Cleanup reverts all changes made by the ControlEvaluation.
 func (c *ControlEvaluation) Cleanup() {
 	for _, assessment := range c.Assessments {
 		corrupted := assessment.RevertChanges()
 		if corrupted {
-			c.Corrupted_State = true
+			c.CorruptedState = true
 		}
 	}
 }
 
-// CloseHandler creates a 'listener' on a new goroutine which will notify the
-// program if it receives an interrupt from the operating system.
-// If an interrupt is received, this will attempt to revert any changes
-// made by the terminated ControlEvaluation.
+// closeHandler creates a 'listener' on a new goroutine which will notify the program if it receives an interrupt from the operating system.
+// If an interrupt is received, this will attempt to revert any changes made by the terminated ControlEvaluation.
 func (c *ControlEvaluation) closeHandler() {
-	// Ref: https://golangcode.com/handle-ctrl-c-exit-in-terminal/
 	channel := make(chan os.Signal, 1)
 	signal.Notify(channel, os.Interrupt, syscall.SIGTERM)
 	go func() {

--- a/layer4/control_evaluation_test.go
+++ b/layer4/control_evaluation_test.go
@@ -107,8 +107,8 @@ func TestEvaluate(t *testing.T) {
 				t.Errorf("Expected Result to be %v, but it was %v", test.expectedResult, c.Result)
 			}
 
-			if c.Corrupted_State != test.expectedCorrupted {
-				t.Errorf("Expected Corrupted_State to be %v, but it was %v", test.expectedCorrupted, c.Corrupted_State)
+			if c.CorruptedState != test.expectedCorrupted {
+				t.Errorf("Expected CorruptedState to be %v, but it was %v", test.expectedCorrupted, c.CorruptedState)
 			}
 		})
 		t.Run(test.testName+"no-changes", func(t *testing.T) {
@@ -130,8 +130,8 @@ func TestEvaluate(t *testing.T) {
 				t.Errorf("Expected Result to be %v, but it was %v", test.expectedResult, c.Result)
 			}
 
-			if c.Corrupted_State != test.expectedCorrupted {
-				t.Errorf("Expected Corrupted_State to be %v, but it was %v", test.expectedCorrupted, c.Corrupted_State)
+			if c.CorruptedState != test.expectedCorrupted {
+				t.Errorf("Expected CorruptedState to be %v, but it was %v", test.expectedCorrupted, c.CorruptedState)
 			}
 		})
 	}

--- a/layer4/test-data.go
+++ b/layer4/test-data.go
@@ -43,7 +43,7 @@ func pendingChangePtr() *Change {
 }
 func pendingChange() Change {
 	return Change{
-		Target_Name: "pendingChange",
+		TargetName:  "pendingChange",
 		Description: "description placeholder",
 		applyFunc:   goodApplyFunc,
 		revertFunc:  goodRevertFunc,
@@ -51,7 +51,7 @@ func pendingChange() Change {
 }
 func appliedRevertedChange() Change {
 	return Change{
-		Target_Name: "appliedRevertedChange",
+		TargetName:  "appliedRevertedChange",
 		Description: "description placeholder",
 		applyFunc:   goodApplyFunc,
 		revertFunc:  goodRevertFunc,
@@ -61,7 +61,7 @@ func appliedRevertedChange() Change {
 }
 func appliedNotRevertedChange() Change {
 	return Change{
-		Target_Name: "appliedNotRevertedChange",
+		TargetName:  "appliedNotRevertedChange",
 		Description: "description placeholder",
 		applyFunc:   goodApplyFunc,
 		revertFunc:  goodRevertFunc,
@@ -74,7 +74,7 @@ func badApplyChangePtr() *Change {
 }
 func badApplyChange() Change {
 	return Change{
-		Target_Name: "badApplyChange",
+		TargetName:  "badApplyChange",
 		Description: "description placeholder",
 		applyFunc:   badApplyFunc,
 		revertFunc:  goodRevertFunc,
@@ -86,7 +86,7 @@ func badRevertChangePtr() *Change {
 }
 func badRevertChange() Change {
 	return Change{
-		Target_Name: "badRevertChange",
+		TargetName:  "badRevertChange",
 		Description: "description placeholder",
 		applyFunc:   goodApplyFunc,
 		revertFunc:  badRevertFunc,
@@ -98,7 +98,7 @@ func goodRevertedChangePtr() *Change {
 }
 func goodRevertedChange() Change {
 	return Change{
-		Target_Name: "goodRevertedChange",
+		TargetName:  "goodRevertedChange",
 		Description: "description placeholder",
 		applyFunc:   goodApplyFunc,
 		revertFunc:  goodRevertFunc,
@@ -111,7 +111,7 @@ func goodNotRevertedChangePtr() *Change {
 }
 func goodNotRevertedChange() Change {
 	return Change{
-		Target_Name: "goodNotRevertedChange",
+		TargetName:  "goodNotRevertedChange",
 		Description: "description placeholder",
 		applyFunc:   goodApplyFunc,
 		revertFunc:  goodRevertFunc,
@@ -124,21 +124,21 @@ func noApplyChangePtr() *Change {
 }
 func noApplyChange() Change {
 	return Change{
-		Target_Name: "noApplyChange",
+		TargetName:  "noApplyChange",
 		Description: "description placeholder",
 		revertFunc:  goodRevertFunc,
 	}
 }
 func noRevertChange() Change {
 	return Change{
-		Target_Name: "noRevertChange",
+		TargetName:  "noRevertChange",
 		Description: "description placeholder",
 		applyFunc:   goodApplyFunc,
 	}
 }
 func disallowedChange() Change {
 	return Change{
-		Target_Name: "disallowedChange",
+		TargetName:  "disallowedChange",
 		Description: "description placeholder",
 		Allowed:     false,
 		applyFunc:   goodApplyFunc,
@@ -153,8 +153,8 @@ func failingAssessmentPtr() *Assessment {
 
 func failingAssessment() Assessment {
 	return Assessment{
-		Requirement_Id: "failingAssessment()",
-		Description:    "failing assessment",
+		RequirementId: "failingAssessment()",
+		Description:   "failing assessment",
 		Steps: []AssessmentStep{
 			failingAssessmentStep,
 			passingAssessmentStep,
@@ -169,8 +169,8 @@ func passingAssessmentPtr() *Assessment {
 
 func passingAssessment() Assessment {
 	return Assessment{
-		Requirement_Id: "passingAssessment()",
-		Description:    "passing assessment",
+		RequirementId: "passingAssessment()",
+		Description:   "passing assessment",
 		Steps: []AssessmentStep{
 			passingAssessmentStep,
 		},
@@ -187,8 +187,8 @@ func needsReviewAssessmentPtr() *Assessment {
 
 func needsReviewAssessment() Assessment {
 	return Assessment{
-		Requirement_Id: "needsReviewAssessment()",
-		Description:    "needs review assessment",
+		RequirementId: "needsReviewAssessment()",
+		Description:   "needs review assessment",
 		Steps: []AssessmentStep{
 			passingAssessmentStep,
 			needsReviewAssessmentStep,
@@ -204,8 +204,8 @@ func unknownAssessmentPtr() *Assessment {
 
 func unknownAssessment() Assessment {
 	return Assessment{
-		Requirement_Id: "unknownAssessment()",
-		Description:    "unknown assessment",
+		RequirementId: "unknownAssessment()",
+		Description:   "unknown assessment",
 		Steps: []AssessmentStep{
 			passingAssessmentStep,
 			unknownAssessmentStep,
@@ -217,8 +217,8 @@ func unknownAssessment() Assessment {
 
 func badRevertPassingAssessment() Assessment {
 	return Assessment{
-		Requirement_Id: "badRevertPassingAssessment()",
-		Description:    "bad revert passing assessment",
+		RequirementId: "badRevertPassingAssessment()",
+		Description:   "bad revert passing assessment",
 		Changes: map[string]*Change{
 			"badRevertChange": badRevertChangePtr(),
 		},


### PR DESCRIPTION
I set out to update the fields with underscores in the name and add the yaml decoding tags. When updating the docs, I realized that all of layer 4 needs updated to follow the [godoc](https://go.dev/blog/godoc) style... so I did that here too.