### PR TITLE
chore: improve Makefile and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,27 +30,17 @@ jobs:
         run: make cuegen
       - name: Check for missing generated artifacts
         run: make dirtycheck
-      - uses: actions/setup-go@v5.4.0
-        with:
-          go-version: "^1.23.4"
-
-      - name: Setup GO environment
-        run: |
-          go mod download
-          go get -u golang.org/x/lint/golint
-          go get -t ./...
-
       - name: Vet
         run: |
           go vet ./...
 
       - name: Unit tests
         run: |
-          make test-cov
+          make testcov
 
       - name: Quality Gate - Test coverage shall be above threshold
         env:
-          TESTCOVERAGE_THRESHOLD: 50
+          TESTCOVERAGE_THRESHOLD: 70
         run: |
           echo "Quality Gate: checking test coverage is above threshold ..."
           echo "Threshold             : $TESTCOVERAGE_THRESHOLD %"
@@ -63,7 +53,3 @@ jobs:
               echo "Failed"
               exit 1
           fi
-
-      - name: Ensure build is functional
-        run: |
-          make build

--- a/Makefile
+++ b/Makefile
@@ -1,139 +1,41 @@
-BUILD_FLAGS=-X 'main.GitCommitHash=`git rev-parse --short HEAD`' -X 'main.BuiltAt=`date +%FT%T%z`' -X 'main.Version=`git describe --tags`'
-BUILD_WIN=@env GOOS=windows GOARCH=amd64 go build -o privateer-windows.exe
-BUILD_LINUX=@env GOOS=linux GOARCH=amd64 go build -o privateer-linux
-BUILD_MAC=@env GOOS=darwin GOARCH=amd64 go build -o privateer-darwin
-
-binary: tidy test build
-quick: build
-testcov: test test-cov
-release: tidy test release-nix release-win release-mac
-
-define build
-echo "  >  Building binary ..."; \
-cd $(1); \
-go build -o ../../$(1) -ldflags="$(BUILD_FLAGS)";
-endef
-
-define test
-echo "  >  Validating code ..."
-cd $(1); \
-go vet ./...
-go test ./...
-endef
-
-build:
-	@$(call build,layer1)
-	@$(call build,layer2)
-	@$(call build,layer4)
-
-test:
-	@$(call test,layer1)
-	@$(call test,layer2)
-	@$(call test,layer4)
+all: tidy test testcov lintcue cuegen dirtycheck lintinsights
+	# Runs all main targets
 
 tidy:
 	@echo "  >  Tidying go.mod ..."
 	@go mod tidy
 
-test-cov:
+test:
+	@echo "  >  Running tests ..."
+	@go vet ./...
+	@go test ./...
+
+testcov:
 	@echo "Running tests and generating coverage output ..."
 	@go test ./... -coverprofile coverage.out -covermode count
 	@sleep 2 # Sleeping to allow for coverage.out file to get generated
 	@echo "Current test coverage : $(shell go tool cover -func=coverage.out | grep total | grep -Eo '[0-9]+\.[0-9]+') %"
 
-release-candidate: tidy test
-	@echo "  >  Building release candidate for Linux..."
-	$(BUILD_LINUX) -ldflags="$(BUILD_FLAGS) -X 'main.VersionPostfix=nix-rc'"
-	@echo "  >  Building release candidate for Windows..."
-	$(BUILD_WIN) -ldflags="$(BUILD_FLAGS) -X 'main.VersionPostfix=win-rc'"
-	@echo "  >  Building release for Darwin..."
-	$(BUILD_MAC) -ldflags="$(BUILD_FLAGS) -X 'main.VersionPostfix=darwin'"
-
-release-nix:
-	@echo "  >  Building release for Linux..."
-	$(BUILD_LINUX) -ldflags="$(BUILD_FLAGS) -X 'main.VersionPostfix=linux'"
-
-release-win:
-	@echo "  >  Building release for Windows..."
-	$(BUILD_WIN) -ldflags="$(BUILD_FLAGS) -X 'main.VersionPostfix=windows'"
-
-release-mac:
-	@echo "  >  Building release for Darwin..."
-	$(BUILD_MAC) -ldflags="$(BUILD_FLAGS) -X 'main.VersionPostfix=darwin'"
-
-todo:
-	@read -p "Write your todo here: " TODO; \
-	echo "- [ ] $$TODO" >> TODO.md
-
 lintcue:
 	@echo "  >  Linting CUE files ..."
-	@echo "  >  Linting layer-1.cue ..."
 	@cue eval ./schemas/layer-1.cue --all-errors --verbose
-	@echo "  >  Linting layer-2.cue ..."
 	@cue eval ./schemas/layer-2.cue --all-errors --verbose
-	@echo "  >  Linting layer-3.cue ..."
 	@cue eval ./schemas/layer-3.cue --all-errors --verbose
-	@echo "  >  Linting layer-4.cue ..."
 	@cue eval ./schemas/layer-4.cue --all-errors --verbose
-
 
 cuegen:
 	@echo "  >  Generating types from cue schema ..."
-
-	@echo "  >  Generating types for layer1 ..."
 	@cue exp gengotypes ./schemas/layer-1.cue
 	@mv cue_types_gen.go layer1/generated_types.go
-
-	@echo "  >  Generating types for layer2 ..."
 	@cue exp gengotypes ./schemas/layer-2.cue
 	@mv cue_types_gen.go layer2/generated_types.go
-
-	@echo "  >  Generating types for layer3 ..."
 	@cue exp gengotypes ./schemas/layer-3.cue
 	@mv cue_types_gen.go layer3/generated_types.go
-
-	@echo "  >  Adding YAML tags to generated_types.go ..."
 	@go build -o utils/types_tagger utils/types_tagger.go
-
-	@echo "  >  Adding YAML tags to layer1/generated_types.go ..."
 	@utils/types_tagger layer1/generated_types.go
-
-	@echo "  >  Adding YAML tags to layer2/generated_types.go ..."
 	@utils/types_tagger layer2/generated_types.go
-
-	@echo "  >  Adding YAML tags to layer3/generated_types.go ..."
 	@utils/types_tagger layer3/generated_types.go
 	@rm utils/types_tagger
-
-
-cuegen-win:
-	@echo "  >  Generating types from cue schema ..."
-
-	@echo "  >  Generating types for layer1 ..."
-	@cue exp gengotypes .\schemas\layer-1.cue
-	@move /Y cue_types_gen.go layer1\generated_types.go
-
-	@echo "  >  Generating types for layer2 ..."
-	@cue exp gengotypes .\schemas\layer-2.cue
-	@move /Y cue_types_gen.go layer2\generated_types.go
-
-	@echo "  >  Generating types for layer3 ..."
-	@cue exp gengotypes .\schemas\layer-3.cue
-	@move /Y cue_types_gen.go layer3\generated_types.go
-
-	@echo "  >  Adding YAML tags to generated_types.go ..."
-	@go build -o utils/types_tagger.exe utils/types_tagger.go
-
-	@echo "  >  Adding YAML tags to layer1/generated_types.go ..."
-	@utils\types_tagger.exe layer1\generated_types.go
-
-	@echo "  >  Adding YAML tags to layer2/generated_types.go ..."
-	@utils\types_tagger.exe layer2\generated_types.go
-
-	@echo "  >  Adding YAML tags to layer3/generated_types.go ..."
-	@utils\types_tagger.exe layer3\generated_types.go
-
-	@del utils\types_tagger.exe
 
 dirtycheck:
 	@echo "  >  Checking for uncommitted changes ..."
@@ -148,8 +50,8 @@ dirtycheck:
 lintinsights:
 	@echo "  >  Linting security-insights.yml ..."
 	@curl -O --silent https://raw.githubusercontent.com/ossf/security-insights-spec/refs/tags/v2.1.0/schema.cue
-	@cue vet security-insights.yml schema.cue
+	@cue vet -d '#SecurityInsights' security-insights.yml schema.cue
 	@rm schema.cue
 	@echo "  >  Linting security-insights.yml complete."
 
-PHONY: lintcue cuegen dirtycheck
+PHONY: tidy test testcov lintcue cuegen dirtycheck lintinsights


### PR DESCRIPTION
This PR simplifies the Makefile significantly to remove unneeded targets. The CI workflow is simplified to remove the install of `golint` as `golangci-lint` is already run in the lint workflow