### PR TITLE
fix: typofix in layer1 generated types

### DIFF
--- a/layer1/generated_types.go
+++ b/layer1/generated_types.go
@@ -38,7 +38,7 @@ type Metadata struct {
 
 	DocumentType	DocumentType	`json:"document-type,omitempty" yaml:"document-type,omitempty"`
 
-	Applicabilty	*Applicability	`json:"applicability,omitempty" yaml:"applicability,omitempty"`
+	Applicability	*Applicability	`json:"applicability,omitempty" yaml:"applicability,omitempty"`
 
 	Exemptions	[]string	`json:"exemptions,omitempty" yaml:"exemptions,omitempty"`
 }

--- a/layer1/testdata.go
+++ b/layer1/testdata.go
@@ -22,7 +22,7 @@ func goodAIGFExample() GuidanceDocument {
 				},
 			},
 			DocumentType: "Framework",
-			Applicabilty: &Applicability{
+			Applicability: &Applicability{
 				TechnologyDomains: []string{
 					"artificial-intelligence",
 				},

--- a/schemas/layer-1.cue
+++ b/schemas/layer-1.cue
@@ -29,7 +29,7 @@ package schemas
 	resources?: [...#ResourceReference] @go(Resources)
 
 	"document-type"?: #DocumentType  @go(DocumentType)
-	applicability?:   #Applicability @go(Applicabilty,optional=nillable)
+	applicability?:   #Applicability @go(Applicability,optional=nillable)
 	exemptions?: [...string]
 }
 


### PR DESCRIPTION
Fixes a typo in the word `Applicability` in layer 1 generated types