### PR TITLE
fix: GitHub Actions - do not persisting credentials after checkouts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version: stable

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5.0.0
+        with:
+          persist-credentials: false
       - uses: actions/setup-go@v6
         with:
           go-version: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,7 @@ jobs:
         uses: actions/checkout@v5.0.0
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Go
         uses: actions/setup-go@v6
         with:


### PR DESCRIPTION
This PR adds security configuration to GitHub Actions workflows by setting persist-credentials: false for checkout actions. This prevents GitHub credentials from being persisted in the Git configuration after repository checkout, reducing potential security risks from credential exposure.

- Added persist-credentials: false to all actions/checkout@v5 steps across multiple workflow files
- Ensures credentials are not available to subsequent steps that don't explicitly need them
- Maintains existing workflow functionality while improving security posture