### PR TITLE
fix: Enforce control and assessment reference documents match

### DIFF
--- a/layer4/generated_types.go
+++ b/layer4/generated_types.go
@@ -66,6 +66,9 @@ type AssessmentPlan struct {
 	Control	Mapping	`json:"control" yaml:"control"`
 
 	// Assessments defines possible testing procedures to evaluate the control.
+	//
+	// Enforce that control reference and the assessments' references match
+	// This formulation uses the control's reference if the assessment doesn't include a reference
 	Assessments	[]Assessment	`json:"assessments" yaml:"assessments"`
 }
 
@@ -81,30 +84,6 @@ type Mapping struct {
 
 	// Remarks provides additional context about the mapping entry.
 	Remarks	string	`json:"remarks,omitempty" yaml:"remarks,omitempty"`
-}
-
-// Assessment defines all testing procedures for a requirement.
-type Assessment struct {
-	// RequirementId points to the requirement being tested.
-	Requirement	Mapping	`json:"requirement" yaml:"requirement"`
-
-	// Procedures defines possible testing procedures to evaluate the requirement.
-	Procedures	[]AssessmentProcedure	`json:"procedures" yaml:"procedures"`
-}
-
-// AssessmentProcedure describes a testing procedure for evaluating a Layer 2 control requirement.
-type AssessmentProcedure struct {
-	// Id uniquely identifies the assessment procedure being executed
-	Id	string	`json:"id" yaml:"id"`
-
-	// Name provides a summary of the procedure
-	Name	string	`json:"name" yaml:"name"`
-
-	// Description provides a detailed explanation of the procedure
-	Description	string	`json:"description" yaml:"description"`
-
-	// Documentation provides a URL to documentation that describes how the assessment procedure evaluates the control requirement
-	Documentation	string	`json:"documentation,omitempty" yaml:"documentation,omitempty"`
 }
 
 // EvaluationLog contains the results of evaluating a set of Layer 2 controls.
@@ -124,6 +103,8 @@ type ControlEvaluation struct {
 
 	Control	Mapping	`json:"control" yaml:"control"`
 
+	// Enforce that control reference and the assessments' references match
+	// This formulation uses the control's reference if the assessment doesn't include a reference
 	AssessmentLogs	[]*AssessmentLog	`json:"assessment-logs" yaml:"assessment-logs"`
 }
 
@@ -164,5 +145,29 @@ type AssessmentLog struct {
 }
 
 type Datetime string
+
+// Assessment defines all testing procedures for a requirement.
+type Assessment struct {
+	// RequirementId points to the requirement being tested.
+	Requirement	Mapping	`json:"requirement" yaml:"requirement"`
+
+	// Procedures defines possible testing procedures to evaluate the requirement.
+	Procedures	[]AssessmentProcedure	`json:"procedures" yaml:"procedures"`
+}
+
+// AssessmentProcedure describes a testing procedure for evaluating a Layer 2 control requirement.
+type AssessmentProcedure struct {
+	// Id uniquely identifies the assessment procedure being executed
+	Id	string	`json:"id" yaml:"id"`
+
+	// Name provides a summary of the procedure
+	Name	string	`json:"name" yaml:"name"`
+
+	// Description provides a detailed explanation of the procedure
+	Description	string	`json:"description" yaml:"description"`
+
+	// Documentation provides a URL to documentation that describes how the assessment procedure evaluates the control requirement
+	Documentation	string	`json:"documentation,omitempty" yaml:"documentation,omitempty"`
+}
 
 type Email string

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -62,7 +62,6 @@ import "time"
 	// This formulation uses the control's reference if the assessment doesn't include a reference
 	"assessment-logs": [...{
 		requirement: "reference-id": (control."reference-id")
-		procedure: "reference-id":   (control."reference-id")
 	}] @go(AssessmentLogs,type=[]*AssessmentLog)
 }
 

--- a/schemas/layer-4.cue
+++ b/schemas/layer-4.cue
@@ -58,6 +58,12 @@ import "time"
 	message: string
 	control: #Mapping
 	"assessment-logs": [...#AssessmentLog] @go(AssessmentLogs,type=[]*AssessmentLog)
+	// Enforce that control reference and the assessments' references match
+	// This formulation uses the control's reference if the assessment doesn't include a reference
+	"assessment-logs": [...{
+		requirement: "reference-id": (control."reference-id")
+		procedure: "reference-id":   (control."reference-id")
+	}] @go(AssessmentLogs,type=[]*AssessmentLog)
 }
 
 // AssessmentLog contains the results of executing a single assessment procedure for a control requirement.
@@ -97,7 +103,12 @@ import "time"
 	// Control points to the Layer 2 control being evaluated.
 	control: #Mapping
 	// Assessments defines possible testing procedures to evaluate the control.
-	assessments: [...#Assessment] @go(Assessments)
+	assessments: [...#Assessment] @go(Assessments,type=[]Assessment)
+	// Enforce that control reference and the assessments' references match
+	// This formulation uses the control's reference if the assessment doesn't include a reference
+	assessments: [...{
+		requirement: "reference-id": (control."reference-id")
+	}] @go(Assessments,type=[]Assessment)
 }
 
 // Assessment defines all testing procedures for a requirement.


### PR DESCRIPTION
See discussion \[in Slack](https://openssf.slack.com/archives/C09A9PP765Q/p1760043482040019):

In particular:

* For any given control, all the assessments and procedures should refer to the same mapping reference document.  Omitting the reference document in the subordinate assessments and procedures defaults it to the same one as the control.
* This was tested with a sample document provided by Eddie in the thread.  The document failed with the following errors (once the mismatched header was removed).  Reported from `cue vet -c .\\schemas\\layer-4.cue .\\tempfile -d '#EvaluationLog'`:

   ```
   evaluations.0."assessment-logs".0.procedure."reference-id": conflicting values "OSPS-Baseline" and "":
        .\temp-openfga-values.yaml:10:23
        .\temp-openfga-values.yaml:17:25
   evaluations.1."assessment-logs".0.procedure."reference-id": conflicting values "OSPS-Baseline" and "":
        .\temp-openfga-values.yaml:45:23
        .\temp-openfga-values.yaml:52:25
   ...
   evaluations.12."assessment-logs".1.start: invalid value "" (does not satisfy time.Format("2006-01-02T15:04:05Z07:00")): error in call to time.Format: invalid time "":
       .\schemas\layer-4.cue:99:12
       .\schemas\layer-4.cue:88:9
       .\schemas\layer-4.cue:99:24
       .\temp-openfga-values.yaml:582:16
   ...
   ```

   The date errors seem to be pre-existing, and could be solved by changing `start` to `#Datetime | ""` or making `start` optional (possibly only for `Not Run` results).
