### PR TITLE
feat: Filter out NotRun and NotApplicable results from SARIF output

### DIFF
--- a/layer4/evaluation_log.go
+++ b/layer4/evaluation_log.go
@@ -39,6 +39,11 @@ func (e EvaluationLog) ToSARIF(artifactURI string) ([]byte, error) {
 				continue
 			}
 
+			// Skip NotRun and NotApplicable results - only include Passed, Failed, NeedsReview, Unknown
+			if log.Result == NotRun || log.Result == NotApplicable {
+				continue
+			}
+
 			ruleID := fmt.Sprintf("%s/%s", evaluation.Control.EntryId, log.Requirement.EntryId)
 			if !ruleIdSeen[ruleID] {
 				rule := ReportingDescriptor{ID: ruleID}


### PR DESCRIPTION
Only include Passed, Failed, NeedsReview, and Unknown results in SARIF. This prevents assessments that weren't evaluated (due to applicability) from appearing as alerts in GitHub Code Scanning.