### PR TITLE
feat: enrich sarif with catalog data

### DIFF
--- a/layer4/evaluation_log.go
+++ b/layer4/evaluation_log.go
@@ -3,6 +3,8 @@ package layer4
 import (
 	"encoding/json"
 	"fmt"
+
+	"github.com/ossf/gemara/layer2"
 )
 
 // ToSARIF converts the evaluation results into a SARIF document (v2.1.0).
@@ -13,11 +15,13 @@ import (
 //   - artifactURI: File path or URI for PhysicalLocation.artifactLocation.uri.
 //     If empty, PhysicalLocation will be nil (no resource URI available).
 //     For GitHub Code Scanning, typically use a file path like "README.md".
+//   - catalog: Optional catalog data to enrich SARIF output with requirement text,
+//     recommendations, and documentation links. If nil, only basic information is included.
 //
 // PhysicalLocation identifies the artifact (file/repository) where the result was found.
 // LogicalLocation identifies the logical component (assessment step) that produced the result.
 // Region is left nil as we don't have file-specific line/column data.
-func (e EvaluationLog) ToSARIF(artifactURI string) ([]byte, error) {
+func (e EvaluationLog) ToSARIF(artifactURI string, catalog *layer2.Catalog) ([]byte, error) {
 	report := &SarifReport{
 		Schema:  "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/123e95847b13fbdd4cbe2120fa5e33355d4a042b/Schemata/sarif-schema-2.1.0.json",
 		Version: "2.1.0",
@@ -52,6 +56,41 @@ func (e EvaluationLog) ToSARIF(artifactURI string) ([]byte, error) {
 				} else if evaluation.Name != "" {
 					rule.Name = evaluation.Name
 				}
+
+				// Enrich rule with catalog data if available
+				if catalog != nil {
+					control, requirement := findControlAndRequirement(catalog, evaluation.Control.EntryId, log.Requirement.EntryId)
+					if control != nil {
+						// Use control title if name is still empty
+						if rule.Name == "" {
+							rule.Name = control.Title
+						}
+
+						// Add requirement text as short description
+						if requirement != nil && requirement.Text != "" {
+							rule.ShortDescription = &Message{Text: requirement.Text}
+						}
+
+						// Add full description: control objective + requirement text
+						if control.Objective != "" {
+							fullDesc := control.Objective
+							if requirement != nil && requirement.Text != "" {
+								fullDesc = fmt.Sprintf("%s\n\nRequirement: %s", control.Objective, requirement.Text)
+							}
+							rule.FullDescription = &Message{Text: fullDesc}
+						}
+
+						// Add recommendation as help text
+						if log.Recommendation != "" {
+							rule.Help = &Message{Text: log.Recommendation}
+						} else if requirement != nil && requirement.Recommendation != "" {
+							rule.Help = &Message{Text: requirement.Recommendation}
+						}
+
+						// HelpUri is left empty - catalog-specific URI generation should be handled by the caller
+					}
+				}
+
 				rules = append(rules, rule)
 				ruleIdSeen[ruleID] = true
 			}
@@ -150,8 +189,12 @@ type ToolComponent struct {
 }
 
 type ReportingDescriptor struct {
-	ID   string `json:"id"`
-	Name string `json:"name,omitempty"`
+	ID               string   `json:"id"`
+	Name             string   `json:"name,omitempty"`
+	ShortDescription *Message `json:"shortDescription,omitempty"`
+	FullDescription  *Message `json:"fullDescription,omitempty"`
+	Help             *Message `json:"help,omitempty"`
+	HelpUri          string   `json:"helpUri,omitempty"`
 }
 
 type ResultEntry struct {
@@ -195,4 +238,31 @@ type Snippet struct {
 
 type LogicalLocation struct {
 	FullyQualifiedName string `json:"fullyQualifiedName,omitempty"`
+}
+
+// findControlAndRequirement searches the catalog for a control and requirement by their IDs.
+// Returns the control and requirement if found, nil otherwise.
+func findControlAndRequirement(catalog *layer2.Catalog, controlID, requirementID string) (*layer2.Control, *layer2.AssessmentRequirement) {
+	if catalog == nil {
+		return nil, nil
+	}
+
+	for _, family := range catalog.ControlFamilies {
+		for i := range family.Controls {
+			control := &family.Controls[i]
+			if control.Id == controlID {
+				// Found the control, now find the requirement
+				for j := range control.AssessmentRequirements {
+					requirement := &control.AssessmentRequirements[j]
+					if requirement.Id == requirementID {
+						return control, requirement
+					}
+				}
+				// Control found but requirement not found
+				return control, nil
+			}
+		}
+	}
+
+	return nil, nil
 }

--- a/layer4/evaluation_log.go
+++ b/layer4/evaluation_log.go
@@ -15,8 +15,8 @@ import (
 //   - artifactURI: File path or URI for PhysicalLocation.artifactLocation.uri.
 //     If empty, PhysicalLocation will be nil (no resource URI available).
 //     For GitHub Code Scanning, typically use a file path like "README.md".
-//   - catalog: Optional catalog data to enrich SARIF output with requirement text,
-//     recommendations, and documentation links. If nil, only basic information is included.
+//   - catalog: Optional catalog data to enrich SARIF output with requirement text
+//     and recommendations. If nil, only basic information is included.
 //
 // PhysicalLocation identifies the artifact (file/repository) where the result was found.
 // LogicalLocation identifies the logical component (assessment step) that produced the result.

--- a/layer4/evaluation_log.go
+++ b/layer4/evaluation_log.go
@@ -39,6 +39,11 @@ func (e EvaluationLog) ToSARIF(artifactURI string) ([]byte, error) {
 				continue
 			}
 
+			// Skip NotRun and NotApplicable results - only include Passed, Failed, NeedsReview, Unknown
+			if log.Result == NotRun || log.Result == NotApplicable {
+				continue
+			}
+
 			ruleID := fmt.Sprintf("%s/%s", evaluation.Control.EntryId, log.Requirement.EntryId)
 			if !ruleIdSeen[ruleID] {
 				rule := ReportingDescriptor{ID: ruleID}

--- a/layer4/to_sarif_test.go
+++ b/layer4/to_sarif_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/ossf/gemara/layer2"
 	"github.com/stretchr/testify/require"
 )
 
@@ -65,7 +66,7 @@ func Test_ToSARIF(t *testing.T) {
 		},
 	}
 	// Test with empty artifactURI - PhysicalLocation should be nil
-	sarifBytes, err := evaluationLog.ToSARIF("")
+	sarifBytes, err := evaluationLog.ToSARIF("", nil)
 	require.NoError(t, err)
 	sarif = &SarifReport{}
 	err = json.Unmarshal(sarifBytes, sarif)
@@ -142,7 +143,7 @@ func Test_ToSARIF_NoPhysicalLocationWhenURIMissing(t *testing.T) {
 		},
 	}
 	// Test without parameter and empty URI - PhysicalLocation should be nil
-	sarifBytes, err := evaluationLog.ToSARIF("")
+	sarifBytes, err := evaluationLog.ToSARIF("", nil)
 	require.NoError(t, err)
 	sarif := &SarifReport{}
 	err = json.Unmarshal(sarifBytes, sarif)
@@ -199,7 +200,7 @@ func Test_ToSARIF_WithArtifactURIParameter(t *testing.T) {
 	}
 
 	// Test with custom artifactURI parameter
-	sarifBytes, err := evaluationLog.ToSARIF(customURI)
+	sarifBytes, err := evaluationLog.ToSARIF(customURI, nil)
 	require.NoError(t, err)
 	sarif := &SarifReport{}
 	err = json.Unmarshal(sarifBytes, sarif)
@@ -217,4 +218,112 @@ func Test_ToSARIF_WithArtifactURIParameter(t *testing.T) {
 	require.NotNil(t, location.PhysicalLocation)
 	require.Equal(t, customURI, location.PhysicalLocation.ArtifactLocation.URI, "Should use provided artifactURI parameter")
 	require.NotEqual(t, "https://github.com/test/repo", location.PhysicalLocation.ArtifactLocation.URI, "Should not use Metadata.Author.Uri when parameter provided")
+}
+
+func Test_ToSARIF_WithCatalogEnrichment(t *testing.T) {
+	// Test that catalog data enriches SARIF output with requirement text, recommendations, and help URI
+	testStep := func(interface{}) (Result, string) {
+		return Failed, ""
+	}
+
+	ce := &ControlEvaluation{
+		Name: "Test Control",
+		Control: Mapping{
+			EntryId: "CTRL-1",
+		},
+		Result: Failed,
+		AssessmentLogs: []*AssessmentLog{
+			{
+				Requirement: Mapping{
+					EntryId: "REQ-1",
+				},
+				Description:    "Test description",
+				Result:         Failed,
+				Message:        "Test failed",
+				Recommendation: "Fix this issue by doing X",
+				Steps:          []AssessmentStep{testStep},
+				StepsExecuted:  1,
+			},
+		},
+	}
+
+	evaluationLog := EvaluationLog{
+		Evaluations: []*ControlEvaluation{ce},
+		Metadata: Metadata{
+			Author: Author{
+				Name:    "test-tool",
+				Uri:     "https://github.com/test/tool",
+				Version: "1.0.0",
+			},
+		},
+	}
+
+	// Create a test catalog with matching control and requirement
+	testCatalog := &layer2.Catalog{
+		ControlFamilies: []layer2.ControlFamily{
+			{
+				Id:    "test-family",
+				Title: "Test Family",
+				Controls: []layer2.Control{
+					{
+						Id:        "CTRL-1",
+						Title:     "Test Control Title",
+						Objective: "Test control objective",
+						AssessmentRequirements: []layer2.AssessmentRequirement{
+							{
+								Id:             "REQ-1",
+								Text:           "This is the requirement text that should appear in SARIF",
+								Recommendation: "This is the catalog recommendation",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	// Test with catalog
+	sarifBytes, err := evaluationLog.ToSARIF("README.md", testCatalog)
+	require.NoError(t, err)
+	sarif := &SarifReport{}
+	err = json.Unmarshal(sarifBytes, sarif)
+	require.NoError(t, err)
+	require.NotNil(t, sarif)
+	require.Len(t, sarif.Runs, 1)
+	run := sarif.Runs[0]
+
+	// Verify rules are enriched with catalog data
+	require.NotNil(t, run.Tool.Driver.Rules)
+	require.Len(t, run.Tool.Driver.Rules, 1)
+	rule := run.Tool.Driver.Rules[0]
+
+	require.Equal(t, "CTRL-1/REQ-1", rule.ID)
+	require.NotNil(t, rule.ShortDescription, "ShortDescription should be populated from requirement text")
+	require.Equal(t, "This is the requirement text that should appear in SARIF", rule.ShortDescription.Text)
+
+	require.NotNil(t, rule.FullDescription, "FullDescription should be populated")
+	require.Contains(t, rule.FullDescription.Text, "Test control objective", "FullDescription should contain control objective")
+	require.Contains(t, rule.FullDescription.Text, "This is the requirement text", "FullDescription should contain requirement text")
+
+	require.NotNil(t, rule.Help, "Help should be populated from AssessmentLog recommendation")
+	require.Equal(t, "Fix this issue by doing X", rule.Help.Text, "Help should prefer AssessmentLog recommendation over catalog")
+
+	// HelpUri is not populated in gemara - catalog-specific URI generation should be handled by the caller
+	require.Empty(t, rule.HelpUri, "HelpUri should be empty as it's catalog-specific")
+
+	// Test without catalog - should still work but without enrichment
+	sarifBytes2, err := evaluationLog.ToSARIF("README.md", nil)
+	require.NoError(t, err)
+	sarif2 := &SarifReport{}
+	err = json.Unmarshal(sarifBytes2, sarif2)
+	require.NoError(t, err)
+	require.Len(t, sarif2.Runs, 1)
+	run2 := sarif2.Runs[0]
+	require.Len(t, run2.Tool.Driver.Rules, 1)
+	rule2 := run2.Tool.Driver.Rules[0]
+
+	require.Nil(t, rule2.ShortDescription, "ShortDescription should be nil without catalog")
+	require.Nil(t, rule2.FullDescription, "FullDescription should be nil without catalog")
+	require.Nil(t, rule2.Help, "Help should be nil without catalog")
+	require.Empty(t, rule2.HelpUri, "HelpUri should be empty without catalog")
 }

--- a/layer4/to_sarif_test.go
+++ b/layer4/to_sarif_test.go
@@ -221,7 +221,7 @@ func Test_ToSARIF_WithArtifactURIParameter(t *testing.T) {
 }
 
 func Test_ToSARIF_WithCatalogEnrichment(t *testing.T) {
-	// Test that catalog data enriches SARIF output with requirement text, recommendations, and help URI
+	// Test that catalog data enriches SARIF output with requirement text, recommendations, and help text
 	testStep := func(interface{}) (Result, string) {
 		return Failed, ""
 	}


### PR DESCRIPTION
Enhances SARIF output to include catalog metadata (requirement text, recommendations) for more informative GitHub Code Scanning alerts.

## Changes

* Add optional `catalog` parameter to `ToSARIF()` function
* Enhance `ReportingDescriptor` with `shortDescription`, `fullDescription`, and `help` fields
* Add `findControlAndRequirement()` helper to lookup catalog data
* `helpUri` is left empty - catalog-specific URI generation should be handled by the caller
* Update tests and add new test for catalog enrichment

## Example Output

<details>
<summary>Click to expand: Example enriched SARIF output with OSPS Baseline catalog data</summary>

This example shows the SARIF output when catalog data is provided to `ToSARIF()`. The output includes enriched rule metadata with requirement text, control objectives, and recommendations from the OSPS Baseline catalog.
son
{
  "$schema": "https://raw.githubusercontent.com/oasis-tcs/sarif-spec/123e95847b13fbdd4cbe2120fa5e33355d4a042b/Schemata/sarif-schema-2.1.0.json",
  "version": "2.1.0",
  "runs": [
    {
      "tool": {
        "driver": {
          "name": "github-repo",
          "informationUri": "https://github.com/revanite-io/pvtr-github-repo",
          "version": "1.0.0",
          "rules": [
            {
              "id": "OSPS-AC-01/OSPS-AC-01.01",
              "name": "When a user attempts to access a sensitive resource in the project's version control system, the system MUST require the user to complete a multi-factor authentication process.",
              "shortDescription": {
                "text": "When a user attempts to read or modify a sensitive resource in the project's authoritative repository, the system MUST require the user to complete a multi-factor authentication process."
              },
              "fullDescription": {
                "text": "Reduce the risk of account compromise or insider threats by requiring multi-factor authentication for collaborators modifying the project repository settings or accessing sensitive data.\n\nRequirement: When a user attempts to read or modify a sensitive resource in the project's authoritative repository, the system MUST require the user to complete a multi-factor authentication process."
              },
              "help": {
                "text": "Enforce multi-factor authentication for the project's version control system, requiring collaborators to provide a second form of authentication when accessing sensitive data or modifying repository settings. Passkeys are acceptable for this control."
              }
            }
          ]
        }
      },
      "results": [
        {
          "ruleId": "OSPS-AC-01/OSPS-AC-01.01",
          "level": "note",
          "message": {
            "text": "Two-factor authentication is configured as required by the parent organization"
          },
          "locations": [
            {
              "physicalLocation": {
                "artifactLocation": {
                  "uri": "README.md"
                }
              },
              "logicalLocations": [
                {
                  "fullyQualifiedName": "github.com/revanite-io/pvtr-github-repo/evaluation_plans/osps/access_control.orgRequiresMFA"
                }
              ]
            }
          ]
        }
      ]
    }
  ]
}</details>