### PR TITLE
ci: Add baseline scanner workflow

### DIFF
--- a/.github/workflows/baseline-scanner.yml
+++ b/.github/workflows/baseline-scanner.yml
@@ -17,10 +17,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: Run Baseline Action
-        uses: revanite-io/osps-baseline-action@v1.0.0
+        uses: revanite-io/osps-baseline-action@ffcef1f33b6ee5b916c7e357e4ae1481b99b46b6 # v1.0.0
         with:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
@@ -30,7 +30,7 @@ jobs:
 
       - name: Upload Assessment Results
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: osps-assessment-results-${{ github.run_number }}
           path: evaluation_results/

--- a/.github/workflows/baseline-scanner.yml
+++ b/.github/workflows/baseline-scanner.yml
@@ -1,0 +1,37 @@
+name: OSPS Baseline Scanner
+
+on:
+  schedule:
+    # Run weekly on Mondays at 9 AM UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  osps-assessment:
+    runs-on: ubuntu-latest
+    name: Baseline Scan
+
+    permissions:
+      contents: read
+      security-events: write # Required for SARIF upload
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Run Baseline Action
+        uses: revanite-io/osps-baseline-action@v1.0.0
+        with:
+          owner: ${{ github.repository_owner }}
+          repo: ${{ github.event.repository.name }}
+          token: ${{ secrets.PVTR_GITHUB_TOKEN }}
+          catalog: "osps-baseline"
+          upload-sarif: "true"
+
+      - name: Upload Assessment Results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: osps-assessment-results-${{ github.run_number }}
+          path: evaluation_results/
+          retention-days: 30


### PR DESCRIPTION
> [!WARNING]
> This requires a PAT in the repo or organization secrets: `PVTR_GITHUB_TOKEN`

I've added my own PAT to the repo secrets. It's got a short-ish expiration set for now. It will need to be rotated later. There is not currently an alternative that I'm aware of to authenticate the scanner to the GitHub API. If anyone has alternative ideas, please log them over on the scanner or action repo.