### PR TITLE
feat: add layer 1 loaders

### DIFF
--- a/layer1/loaders.go
+++ b/layer1/loaders.go
@@ -1,0 +1,51 @@
+package layer1
+
+import (
+	"fmt"
+	"path"
+
+	"github.com/ossf/gemara/internal/loaders"
+)
+
+// LoadFiles loads data from any number of YAML or JSON files at the provided paths.
+// sourcePath are expected to be file or https URIs in the form file:///path/to/file.yaml or https://example.com/file.yaml.
+// If run multiple times, this method will append new data to previous data.
+func (g *GuidanceDocument) LoadFiles(sourcePaths []string) error {
+	for _, sourcePath := range sourcePaths {
+		doc := &GuidanceDocument{}
+		if err := doc.LoadFile(sourcePath); err != nil {
+			return err
+		}
+		if g.Metadata.Id == "" {
+			g.Metadata = doc.Metadata
+		}
+		g.Categories = append(g.Categories, doc.Categories...)
+		g.ImportedGuidelines = append(g.ImportedGuidelines, doc.ImportedGuidelines...)
+		g.ImportedPrinciples = append(g.ImportedPrinciples, doc.ImportedPrinciples...)
+	}
+	return nil
+}
+
+// LoadFile loads data from a YAML or JSON file at the provided path into the GuidanceDocument.
+// sourcePath is expected to be a file or https URI in the form file:///path/to/file.yaml or https://example.com/file.yaml.
+// If run multiple times for the same data type, this method will override previous data.
+func (g *GuidanceDocument) LoadFile(sourcePath string) error {
+	ext := path.Ext(sourcePath)
+	switch ext {
+	case ".yaml", ".yml":
+		err := loaders.LoadYAML(sourcePath, g)
+		if err != nil {
+			return err
+		}
+	case ".json":
+		err := loaders.LoadJSON(sourcePath, g)
+		if err != nil {
+			return fmt.Errorf("error loading json: %w", err)
+		}
+	default:
+		return fmt.Errorf("unsupported file extension: %s", ext)
+	}
+	return nil
+}
+
+

--- a/layer1/loaders_test.go
+++ b/layer1/loaders_test.go
@@ -1,0 +1,107 @@
+package layer1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_LoadFile(t *testing.T) {
+	tests := []struct {
+		name       string
+		sourcePath string
+		wantErr    bool
+	}{
+		{
+			name:       "Bad path",
+			sourcePath: "file://test-data/bad.yaml",
+			wantErr:    true,
+		},
+		{
+			name:       "Good YAML — AIGF",
+			sourcePath: "file://test-data/good-aigf.yaml",
+			wantErr:    false,
+		},
+		{
+			name:       "Unsupported file extension",
+			sourcePath: "file://test-data/unsupported.txt",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GuidanceDocument{}
+			err := g.LoadFile(tt.sourcePath)
+			if (err == nil) == tt.wantErr {
+				t.Errorf("GuidanceDocument.LoadFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr {
+				assert.NotEmpty(t, g.Metadata.Id, "Guidance document ID should not be empty")
+				assert.NotEmpty(t, g.Metadata.Title, "Guidance document title should not be empty")
+				if len(g.Categories) == 0 {
+					t.Errorf("GuidanceDocument.LoadFile() did not load any categories")
+				}
+			}
+		})
+	}
+}
+
+func Test_LoadFiles_AppendsData(t *testing.T) {
+	one := &GuidanceDocument{}
+	require.NoError(t, one.LoadFile("file://test-data/good-aigf.yaml"))
+	require.Greater(t, len(one.Categories), 0, "expected at least one category in good-aigf.yaml")
+
+	g := &GuidanceDocument{}
+	err := g.LoadFiles([]string{
+		"file://test-data/good-aigf.yaml",
+		"file://test-data/good-aigf.yaml",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, one.Metadata, g.Metadata, "first document's metadata should be preserved")
+	assert.Equal(t, len(one.Categories)*2, len(g.Categories), "categories should be appended across multiple files")
+}
+
+func Test_LoadFile_Uri(t *testing.T) {
+	tests := []struct {
+		name          string
+		sourcePath    string
+		wantErr       bool
+		errorExpected string
+	}{
+		{
+			name:          "URI that returns a 404",
+			sourcePath:    "https://example.com/nonexistent.yaml",
+			wantErr:       true,
+			errorExpected: "failed to fetch URL; response status: 404 Not Found",
+		},
+		{
+			name:       "Valid URI with valid data",
+			sourcePath: "https://raw.githubusercontent.com/ossf/security-baseline/refs/heads/main/baseline/OSPS-AC.yaml",
+			wantErr:    false,
+		},
+		{
+			name:       "Valid URI with invalid data",
+			sourcePath: "https://github.com/ossf/security-insights-spec/releases/download/v2.0.0/template-minimum.yml",
+			wantErr:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := &GuidanceDocument{}
+			err := data.LoadFile(tt.sourcePath)
+			if err != nil && tt.wantErr {
+				assert.Containsf(t, err.Error(), tt.errorExpected, "expected error containing %q, got %s", tt.errorExpected, err)
+			} else if err == nil && tt.wantErr {
+				t.Errorf("GuidanceDocument.LoadFile() expected error matching %s, got nil.", tt.errorExpected)
+			} else if err != nil && !tt.wantErr {
+				t.Errorf("GuidanceDocument.LoadFile() did not expect error, but got '%s'", err.Error())
+			}
+		})
+	}
+}
+
+

--- a/utils/oscal/export/oscal_exporter.go
+++ b/utils/oscal/export/oscal_exporter.go
@@ -7,7 +7,6 @@ import (
 	"os"
 
 	oscal "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
-	"github.com/goccy/go-yaml"
 
 	"github.com/ossf/gemara/layer1"
 	"github.com/ossf/gemara/layer2"
@@ -21,13 +20,9 @@ func Guidance(path string, args []string) error {
 		return err
 	}
 
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return err
-	}
-
 	var guidanceDocument layer1.GuidanceDocument
-	if err := yaml.Unmarshal(data, &guidanceDocument); err != nil {
+	pathWithScheme := fmt.Sprintf("file://%s", path)
+	if err := guidanceDocument.LoadFile(pathWithScheme); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This PR adds file loaders for layer 1.

- https://github.com/ossf/gemara/commit/66daaff0fd6e4cb274856a6a5c3b94e18aa3b502 adds loaders and tests
- https://github.com/ossf/gemara/commit/006f05109ca16380f5947f0a1da31886c5600ca7 updates OSCAL exporter to use new loader


Fixes https://github.com/ossf/gemara/issues/185

> Assisted by: Cursor Agent