### PR TITLE
docs: updates documentation site config to include url information

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ go.work.sum
 
 # artifacts
 artifacts/
+
+# docs
+docs/_site

--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ serve: check-container
 	@echo "  >  Using container runtime: $(CONTAINER_CMD)"
 	@$(CONTAINER_CMD) stop gemara-docs 2>/dev/null || true
 	@$(CONTAINER_CMD) rm gemara-docs 2>/dev/null || true
-	@echo "  >  Site will be available at: http://localhost:4000"
+	@echo "  >  Site will be available at: http://localhost:4000/gemara"
 	@echo ""
 	@$(CONTAINER_CMD) run --rm \
 		--name gemara-docs \

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,8 +1,9 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.7)
-      public_suffix (>= 2.0.2, < 7.0)
+    addressable (2.8.8)
+      public_suffix (>= 2.0.2, < 8.0)
+    bigdecimal (3.3.1)
     colorator (1.1.0)
     concurrent-ruby (1.3.5)
     em-websocket (0.5.3)
@@ -10,8 +11,44 @@ GEM
       http_parser.rb (~> 0)
     eventmachine (1.2.7)
     ffi (1.17.2)
+    ffi (1.17.2-aarch64-linux-gnu)
+    ffi (1.17.2-aarch64-linux-musl)
+    ffi (1.17.2-arm-linux-gnu)
+    ffi (1.17.2-arm-linux-musl)
+    ffi (1.17.2-arm64-darwin)
+    ffi (1.17.2-x86-linux-gnu)
+    ffi (1.17.2-x86-linux-musl)
+    ffi (1.17.2-x86_64-darwin)
+    ffi (1.17.2-x86_64-linux-gnu)
+    ffi (1.17.2-x86_64-linux-musl)
     forwardable-extended (2.6.0)
-    google-protobuf (3.23.4)
+    google-protobuf (4.33.1)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-aarch64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-aarch64-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-arm64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86-linux-musl)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86_64-darwin)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86_64-linux-gnu)
+      bigdecimal
+      rake (>= 13)
+    google-protobuf (4.33.1-x86_64-linux-musl)
+      bigdecimal
+      rake (>= 13)
     http_parser.rb (0.8.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
@@ -53,31 +90,77 @@ GEM
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
-    minima (2.5.1)
+    minima (2.5.2)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
-    public_suffix (5.1.1)
+    public_suffix (7.0.0)
     rake (13.3.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.4)
-    rouge (3.30.0)
+    rouge (4.6.1)
     rubyzip (2.4.1)
     safe_yaml (1.0.5)
-    sass-embedded (1.58.3)
-      google-protobuf (~> 3.21)
-      rake (>= 10.0.0)
+    sass-embedded (1.94.2)
+      google-protobuf (~> 4.31)
+      rake (>= 13)
+    sass-embedded (1.94.2-aarch64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-aarch64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-aarch64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-arm-linux-androideabi)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-arm-linux-gnueabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-arm-linux-musleabihf)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-arm64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-riscv64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-riscv64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-riscv64-linux-musl)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-x86_64-darwin)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-x86_64-linux-android)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-x86_64-linux-gnu)
+      google-protobuf (~> 4.31)
+    sass-embedded (1.94.2-x86_64-linux-musl)
+      google-protobuf (~> 4.31)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
     unicode-display_width (2.6.0)
-    webrick (1.9.1)
+    webrick (1.9.2)
 
 PLATFORMS
+  aarch64-linux-android
+  aarch64-linux-gnu
+  aarch64-linux-musl
+  arm-linux-androideabi
+  arm-linux-gnu
+  arm-linux-gnueabihf
+  arm-linux-musl
+  arm-linux-musleabihf
+  arm64-darwin
+  riscv64-linux-android
+  riscv64-linux-gnu
+  riscv64-linux-musl
   ruby
+  x86-linux-gnu
+  x86-linux-musl
+  x86_64-darwin
+  x86_64-linux-android
+  x86_64-linux-gnu
+  x86_64-linux-musl
 
 DEPENDENCIES
   http_parser.rb (~> 0.6.0)
@@ -94,4 +177,4 @@ RUBY VERSION
    ruby 3.1.1p18
 
 BUNDLED WITH
-   1.17.2
+   2.6.9

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -5,8 +5,8 @@ description: >-
   GRC Engineering Model for Automated Risk Assessment - A logical model to describe
   compliance activities, their interactions, and schemas for automated interoperability.
 
-baseurl: ""
-url: ""
+url: "https://ossf.github.io"
+baseurl: "/gemara"
 
 titles_from_headings:
   enabled:     true
@@ -26,7 +26,7 @@ plugins:
 
 # Navigation
 header_pages:
-  - docs/index.md
+  - index.md
 
 # Exclude from processing
 exclude:


### PR DESCRIPTION
## Description

This PR updates the documentation site config to add proper base path configuration for GitHub Pages. We should get a `CNAME` setup after this.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [X] No schema changes
- [ ] Layer 1 schema (`schemas/layer-1.cue`) changes
- [ ] Layer 2 schema (`schemas/layer-2.cue`) changes
- [ ] Layer 3 schema (`schemas/layer-3.cue`) changes
- [ ] Layer 4 schema (`schemas/layer-4.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [X] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->

I validated this locally with jeykll running on my local machine due to some complications with running this in a container with `podman`. It may be good for a reviewer to verify this in the container environment as well.
