### PR TITLE
fix(docs): resolve font slant issue on mobile

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -73,9 +73,33 @@ html, body {
 
 @font-face {
   font-family: "Cairo";
-  src: url("{{ '/assets/fonts/Cairo/Cairo-VariableFont_slnt,wght.ttf' | relative_url }}") format("truetype");
-  font-weight: 200 900;
-  font-style: oblique -12deg 12deg;
+  src: url("{{ '/assets/fonts/Cairo/static/Cairo-Regular.ttf' | relative_url }}") format("truetype");
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Cairo";
+  src: url("{{ '/assets/fonts/Cairo/static/Cairo-Medium.ttf' | relative_url }}") format("truetype");
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Cairo";
+  src: url("{{ '/assets/fonts/Cairo/static/Cairo-SemiBold.ttf' | relative_url }}") format("truetype");
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: "Cairo";
+  src: url("{{ '/assets/fonts/Cairo/static/Cairo-Bold.ttf' | relative_url }}") format("truetype");
+  font-weight: 700;
+  font-style: normal;
   font-display: swap;
 }
 
@@ -182,7 +206,7 @@ p {
   font-size: 1.25em;
   line-height: 1.6;
   margin-bottom: var(--spacing-lg);
-  
+
   /* Ensure badges in status lines are appropriately sized */
   .badge {
     font-size: 0.875rem;
@@ -569,7 +593,7 @@ a[href^="http"]:not([href*="gemara"]):not([href*="openssf"]):not(.social-media-l
   max-width: 120px;
   height: auto;
   margin: 0 0 var(--spacing-md) var(--spacing-lg);
-  
+
   @media screen and (max-width: 600px) {
     float: none;
     display: block;
@@ -607,7 +631,7 @@ a[href^="http"]:not([href*="gemara"]):not([href*="openssf"]):not(.social-media-l
   color: #ffffff;
   font-family: "IBMPlexSans", -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
   position: relative;
-  
+
   .layer-number {
     font-size: 3rem;
     font-weight: 700;
@@ -615,18 +639,18 @@ a[href^="http"]:not([href*="gemara"]):not([href*="openssf"]):not(.social-media-l
     margin-right: var(--spacing-lg);
     flex-shrink: 0;
   }
-  
+
   .layer-content {
     flex: 1;
     text-align: center;
-    
+
     .layer-title {
       font-size: 1.5rem;
       font-weight: 700;
       margin-bottom: var(--spacing-xs);
       line-height: 1.2;
     }
-    
+
     .layer-description {
       font-size: 1rem;
       font-weight: 400;
@@ -653,11 +677,11 @@ a[href^="http"]:not([href*="gemara"]):not([href*="openssf"]):not(.social-media-l
   width: 75%;
   margin: 0 auto;
   border-radius: 0;
-  
+
   .layer-content {
     text-align: center;
     width: 100%;
-    
+
     .layer-title,
     .layer-description {
       text-align: center;
@@ -682,26 +706,26 @@ a[href^="http"]:not([href*="gemara"]):not([href*="openssf"]):not(.social-media-l
     padding: var(--spacing-md);
     gap: var(--spacing-sm);
   }
-  
+
   .layer-banner {
     padding: var(--spacing-md) var(--spacing-lg);
-    
+
     .layer-number {
       font-size: 2rem;
       margin-right: var(--spacing-md);
     }
-    
+
     .layer-content {
       .layer-title {
         font-size: 1.25rem;
       }
-      
+
       .layer-description {
         font-size: 0.9rem;
       }
     }
   }
-  
+
   .layer-sensitive {
     width: 85%;
   }
@@ -712,8 +736,8 @@ a[href^="http"]:not([href*="gemara"]):not([href*="openssf"]):not(.social-media-l
    ============================================ */
 
 @mixin card-base {
-  background: linear-gradient(180deg, 
-    var(--color-bg-primary) 0%, 
+  background: linear-gradient(180deg,
+    var(--color-bg-primary) 0%,
     var(--color-bg-secondary) 100%);
   border: 2px solid var(--color-border);
   border-radius: var(--radius-md);
@@ -728,8 +752,8 @@ a[href^="http"]:not([href*="gemara"]):not([href*="openssf"]):not(.social-media-l
     box-shadow: var(--shadow-md);
     border-color: var(--openssf-purple-light);
     transform: translateY(-2px);
-    background: linear-gradient(180deg, 
-      var(--color-bg-primary) 0%, 
+    background: linear-gradient(180deg,
+      var(--color-bg-primary) 0%,
       rgba(114, 83, 237, 0.05) 100%);
   }
 


### PR DESCRIPTION
## Description

Fixes font rendering issues on mobile devices where the Cairo variable font's `slnt` axis caused backward italic rendering. Also updates gem dependencies.

### Problem

The Cairo variable font (`Cairo-VariableFont_slnt,wght.ttf`) includes a `slnt` (slant) axis that caused:
- Backward/reversed italic text on mobile Safari and some Android browsers
- Inconsistent font rendering across devices

### Solution

Replaced the variable font with static font files that don't include the problematic slant axis:
- `Cairo-Regular.ttf` (weight 400)
- `Cairo-Medium.ttf` (weight 500)
- `Cairo-SemiBold.ttf` (weight 600)
- `Cairo-Bold.ttf` (weight 700)

### Changes

| File | Change |
|------|--------|
| `docs/assets/css/style.scss` | Updated `@font-face` declarations to use static fonts |
| `docs/Gemfile.lock` | Updated gem dependencies |

### Architecture

**Base:** Jekyll Minima theme  
**Customization:** OpenSSF brand colors, typography, and layout overrides

| Component | Customization |
|-----------|---------------|
| Fonts | Cairo (body) + IBM Plex Sans (headers) — self-hosted static fonts for GDPR compliance |
| Colors | OpenSSF purple (#45208c), green (#04ee5f), and brand variations |
| Layout | Custom `default.html` with OpenSSF logo and Font Awesome icons |
| Header | Logo + site title side-by-side branding |
| Footer | Social links (GitHub, X, Bluesky, LinkedIn) |

### What was kept (OpenSSF brand customization)

- Self-hosted fonts (Cairo, IBM Plex Sans) — GDPR compliant, no third-party requests
- OpenSSF brand colors (purple palette, green accents)
- Custom header/footer with purple borders
- Branded blockquote, code, and table styling
- `.layer-grid` component for homepage
- Social media icon styling with Font Awesome

### Maintenance Benefits

| Aspect | Benefit |
|--------|---------|
| Static fonts | No variable font rendering issues across devices |
| Self-hosted fonts | No external dependencies, GDPR compliant |
| Local layouts | No surprise breaking changes from theme updates |

### Testing

- [x] Desktop: Fonts render correctly (Chrome, Firefox, Safari)
- [x] Mobile: No backward italic slant issue
- [x] Social media icons visible in footer
- [x] Brand colors applied consistently
- [x] `bundle exec jekyll build` succeeds

### Checklist

- [x] Clear title conforming to [Conventional Commits spec](https://www.conventionalcommits.org/)
- [x] DCO signoff on commits
- [x] No breaking changes

### Desktop version preview

<img width="2362" height="1692" alt="CleanShot 2025-12-17 at 12 43 46@2x" src="https://github.com/user-attachments/assets/ec2171bf-7895-43ba-92cf-a663e0d8121f" />

### Mobile version preview

<img width="764" height="1464" alt="CleanShot 2025-12-17 at 12 43 03@2x" src="https://github.com/user-attachments/assets/7bfd895d-f21c-4b57-9614-09e10a34c428" />
<img width="776" height="1476" alt="CleanShot 2025-12-17 at 12 43 28@2x" src="https://github.com/user-attachments/assets/addf5e84-fe9c-4459-9be5-3c16e280771d" />

