### PR TITLE
feat!: removes imported guidelines from Layer 1

### DIFF
--- a/generated_types.go
+++ b/generated_types.go
@@ -260,13 +260,11 @@ type AssessmentLog struct {
 }
 
 type GuidanceDocument struct {
-	Metadata Metadata `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-
 	Title string `json:"title" yaml:"title"`
 
-	DocumentType DocumentType `json:"document-type" yaml:"document-type"`
+	Metadata Metadata `json:"metadata" yaml:"metadata"`
 
-	Exemptions []Exemption `json:"exemptions,omitempty" yaml:"exemptions,omitempty"`
+	DocumentType DocumentType `json:"document-type" yaml:"document-type"`
 
 	// Introductory text for the document to be used during rendering
 	FrontMatter string `json:"front-matter,omitempty" yaml:"front-matter,omitempty"`
@@ -275,21 +273,12 @@ type GuidanceDocument struct {
 
 	Guidelines []Guideline `json:"guidelines,omitempty" yaml:"guidelines,omitempty"`
 
-	// For inheriting from other guidance documents to create tailored documents/baselines
-	ImportedGuidelines []MultiMapping `json:"imported-guidelines,omitempty" yaml:"imported-guidelines,omitempty"`
-
-	ImportedPrinciples []MultiMapping `json:"imported-principles,omitempty" yaml:"imported-principles,omitempty"`
+	Exemptions []Exemption `json:"exemptions,omitempty" yaml:"exemptions,omitempty"`
 }
 
 type DocumentType string
 
-// Exemption represents an exemption with a reason and optional redirect
-type Exemption struct {
-	Reason string `json:"reason" yaml:"reason"`
-
-	Redirect MultiMapping `json:"redirect,omitempty" yaml:"redirect,omitempty"`
-}
-
+// Guideline represents a single guideline within a guidance document
 type Guideline struct {
 	Id string `json:"id" yaml:"id"`
 
@@ -303,49 +292,37 @@ type Guideline struct {
 	// Maps to fields commonly seen in controls with implementation guidance
 	Recommendations []string `json:"recommendations,omitempty" yaml:"recommendations,omitempty"`
 
-	// For control enhancements (ex. AC-2(1) in 800-53)
-	// The base-guideline-id is needed to achieve full context for the enhancement
-	BaseGuidelineID string `json:"base-guideline-id,omitempty" yaml:"base-guideline-id,omitempty"`
+	// Extends allows you to add supplemental guidance within a local guidance document
+	// like a control enhancement or from an imported guidance document.
+	Extends *SingleMapping `json:"extends,omitempty" yaml:"extends,omitempty"`
+
+	// Applicability specifies the contexts in which this guideline applies.
+	Applicability []string `json:"applicability,omitempty" yaml:"applicability,omitempty"`
 
 	Rationale *Rationale `json:"rationale,omitempty" yaml:"rationale,omitempty"`
 
-	// Represents individual guideline parts/statements
-	GuidelineParts []Part `json:"guideline-parts,omitempty" yaml:"guideline-parts,omitempty"`
+	Statements []Statement `json:"statements,omitempty" yaml:"statements,omitempty"`
 
-	// Crosswalking this guideline to other guidelines in other documents
 	GuidelineMappings []MultiMapping `json:"guideline-mappings,omitempty" yaml:"guideline-mappings,omitempty"`
 
 	// A list for associated key principle ids
 	PrincipleMappings []MultiMapping `json:"principle-mappings,omitempty" yaml:"principle-mappings,omitempty"`
 
-	// This is akin to related controls, but using more explicit terminology
+	// SeeAlso lists related guideline IDs within the same Guidance document.
 	SeeAlso []string `json:"see-also,omitempty" yaml:"see-also,omitempty"`
 }
 
 // Rationale provides contextual information to help with development and understanding of
 // guideline intent.
 type Rationale struct {
-	// Negative results expected from the guideline's lack of implementation
-	Risks []Risk `json:"risks" yaml:"risks"`
+	Importance string `json:"importance" yaml:"importance"`
 
-	// Positive results expected from the guideline's implementation
-	Outcomes []Outcome `json:"outcomes" yaml:"outcomes"`
+	Goals []string `json:"goals" yaml:"goals"`
 }
 
-type Risk struct {
-	Title string `json:"title" yaml:"title"`
-
-	Description string `json:"description" yaml:"description"`
-}
-
-type Outcome struct {
-	Title string `json:"title" yaml:"title"`
-
-	Description string `json:"description" yaml:"description"`
-}
-
-// Parts include sub-statements of a guideline that can be assessed individually
-type Part struct {
+// Statement represents a structural sub-requirement within a guideline
+// They do not increase strictness and all statements within a guideline apply together.
+type Statement struct {
 	Id string `json:"id" yaml:"id"`
 
 	Title string `json:"title,omitempty" yaml:"title,omitempty"`
@@ -353,6 +330,18 @@ type Part struct {
 	Text string `json:"text" yaml:"text"`
 
 	Recommendations []string `json:"recommendations,omitempty" yaml:"recommendations,omitempty"`
+}
+
+// Exemption represents those who are exempt from the full guidance document.
+type Exemption struct {
+	// Description identifies who or what is exempt from the full guidance
+	Description string `json:"description" yaml:"description"`
+
+	// Reason explains why the exemption is granted
+	Reason string `json:"reason" yaml:"reason"`
+
+	// Redirect points to alternative guidelines or controls that should be followed instead
+	Redirect *MultiMapping `json:"redirect,omitempty" yaml:"redirect,omitempty"`
 }
 
 // Policy represents a policy document with metadata, contacts, scope, imports, implementation plan, risks, and adherence requirements.

--- a/loaders.go
+++ b/loaders.go
@@ -42,8 +42,6 @@ func (g *GuidanceDocument) LoadFiles(sourcePaths []string) error {
 		}
 		g.Families = append(g.Families, doc.Families...)
 		g.Guidelines = append(g.Guidelines, doc.Guidelines...)
-		g.ImportedGuidelines = append(g.ImportedGuidelines, doc.ImportedGuidelines...)
-		g.ImportedPrinciples = append(g.ImportedPrinciples, doc.ImportedPrinciples...)
 	}
 	return nil
 }

--- a/oscal/guidance_test.go
+++ b/oscal/guidance_test.go
@@ -1,11 +1,9 @@
 package oscal
 
 import (
-	"os"
 	"testing"
 
 	oscalTypes "github.com/defenseunicorns/go-oscal/src/types/oscal-1-1-3"
-	"github.com/goccy/go-yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/ossf/gemara"
@@ -279,75 +277,38 @@ func TestToCatalogFromGuidance(t *testing.T) {
 	}
 }
 
-func TestToProfileFromGuidance(t *testing.T) {
+func TestProfileFromGuidanceDocument(t *testing.T) {
 	goodAIFG, err := goodAIGFExample()
 	require.NoError(t, err)
 
-	guidanceWithImports := goodAIFG
-	// Add some shared guidelines
-	mapping := gemara.MappingReference{
-		Id:          "EXP",
-		Description: "Example",
-		Version:     "0.1.0",
-		Url:         "https://example.com",
-	}
-
-	importedGuidelines := gemara.MultiMapping{
-		ReferenceId: "EXP",
-		Entries: []gemara.MappingEntry{
-			{
-				ReferenceId: "EX-1",
-			},
-			{
-				// Intentionally adding a control that
-				// needs to be normalized
-				ReferenceId: "EX-1(2)",
-			},
-			{
-				ReferenceId: "EX-2",
-			},
-		},
-	}
-	guidanceWithImports.Metadata.MappingReferences = append(guidanceWithImports.Metadata.MappingReferences, mapping)
-	guidanceWithImports.ImportedGuidelines = append(guidanceWithImports.ImportedGuidelines, importedGuidelines)
+	guidanceWithImports := guidanceWithImports(goodAIFG)
+	guidanceWithExternalExtends := guidanceWithExternalExtends()
+	guidanceWithMerging := guidanceWithMerging()
+	guidanceWithLocalExtends := guidanceWithLocalExtends()
 
 	tests := []struct {
-		name        string
-		guidance    gemara.GuidanceDocument
-		options     []GenerateOption
-		wantImports []oscalTypes.Import
+		name               string
+		guidance           gemara.GuidanceDocument
+		options            []GenerateOption
+		wantModify         bool
+		wantAlterations    int
+		wantImports        int
+		wantImportControls bool
+		assertFunc         func(*testing.T, oscalTypes.Profile)
 	}{
 		{
-			name:     "Success/LocalOnly",
-			guidance: goodAIFG,
-			wantImports: []oscalTypes.Import{
-				{
-					Href:       "testHref",
-					IncludeAll: &oscalTypes.IncludeAll{},
-				},
-			},
+			name:               "Success/LocalOnly",
+			guidance:           goodAIFG,
+			wantModify:         false,
+			wantImports:        1,
+			wantImportControls: false,
 		},
 		{
-			name:     "Success/WithImports",
-			guidance: guidanceWithImports,
-			wantImports: []oscalTypes.Import{
-				{
-					Href: "https://example.com",
-					IncludeControls: &[]oscalTypes.SelectControlById{
-						{
-							WithIds: &[]string{
-								"ex-1",
-								"ex-1.2",
-								"ex-2",
-							},
-						},
-					},
-				},
-				{
-					Href:       "testHref",
-					IncludeAll: &oscalTypes.IncludeAll{},
-				},
-			},
+			name:               "Success/WithImports",
+			guidance:           guidanceWithImports,
+			wantModify:         false,
+			wantImports:        1,
+			wantImportControls: false,
 		},
 		{
 			name:     "Success/WithImportOverride",
@@ -357,24 +318,43 @@ func TestToProfileFromGuidance(t *testing.T) {
 					"EXP": "https://example.com/oscal",
 				}),
 			},
-			wantImports: []oscalTypes.Import{
-				{
-					Href: "https://example.com/oscal",
-					IncludeControls: &[]oscalTypes.SelectControlById{
-						{
-							WithIds: &[]string{
-								"ex-1",
-								"ex-1.2",
-								"ex-2",
-							},
-						},
-					},
-				},
-				{
-					Href:       "testHref",
-					IncludeAll: &oscalTypes.IncludeAll{},
-				},
+			wantModify:         false,
+			wantImports:        1,
+			wantImportControls: false,
+		},
+		{
+			name:     "Success/WithExternalExtends",
+			guidance: guidanceWithExternalExtends,
+			options: []GenerateOption{
+				WithOSCALImports(map[string]string{
+					"NIST-800-53": "https://nist.gov/800-53",
+				}),
 			},
+			wantModify:         true,
+			wantAlterations:    1,
+			wantImports:        2,
+			wantImportControls: true,
+		},
+		{
+			name:     "Success/WithMerging",
+			guidance: guidanceWithMerging,
+			options: []GenerateOption{
+				WithOSCALImports(map[string]string{
+					"NIST-800-53": "https://nist.gov/800-53",
+				}),
+			},
+			wantModify:         true,
+			wantAlterations:    1,
+			wantImports:        2,
+			wantImportControls: true,
+			assertFunc:         assertMergedParts,
+		},
+		{
+			name:               "Success/WithLocalExtends",
+			guidance:           guidanceWithLocalExtends,
+			wantModify:         false,
+			wantImports:        1,
+			wantImportControls: false,
 		},
 	}
 
@@ -382,23 +362,74 @@ func TestToProfileFromGuidance(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			_, profile, err := FromGuidance(&tt.guidance, "testHref", tt.options...)
 			require.NoError(t, err)
-			profileModel := oscalTypes.OscalModels{Profile: &profile}
-			assert.NoError(t, oscalUtils.Validate(profileModel))
+			oscalDocument := oscalTypes.OscalModels{
+				Profile: &profile,
+			}
+			assert.NoError(t, oscalUtils.Validate(oscalDocument))
 
-			assert.Equal(t, tt.wantImports, profile.Imports)
+			if tt.wantModify {
+				require.NotNil(t, profile.Modify)
+				require.NotNil(t, profile.Modify.Alters)
+				assert.Equal(t, tt.wantAlterations, len(*profile.Modify.Alters))
+
+				alterations := *profile.Modify.Alters
+				assert.Equal(t, "ac-1", alterations[0].ControlId)
+				require.NotNil(t, alterations[0].Adds)
+				assert.Greater(t, len(*alterations[0].Adds), 0)
+			} else {
+				assert.Nil(t, profile.Modify)
+			}
+
+			assert.Equal(t, tt.wantImports, len(profile.Imports))
+
+			hasControlImport := false
+			for _, imp := range profile.Imports {
+				if imp.IncludeControls != nil {
+					hasControlImport = true
+					selectors := *imp.IncludeControls
+					assert.Greater(t, len(selectors), 0)
+					if len(selectors) > 0 {
+						assert.NotNil(t, selectors[0].WithIds)
+						controlIds := *selectors[0].WithIds
+						assert.Contains(t, controlIds, "ac-1")
+					}
+				}
+			}
+			assert.Equal(t, tt.wantImportControls, hasControlImport)
+
+			if tt.assertFunc != nil {
+				tt.assertFunc(t, profile)
+			}
 		})
 	}
 }
 
-func goodAIGFExample() (gemara.GuidanceDocument, error) {
-	testdataPath := "../test-data/good-aigf.yaml"
-	data, err := os.ReadFile(testdataPath)
-	if err != nil {
-		return gemara.GuidanceDocument{}, err
+func assertMergedParts(t *testing.T, profile oscalTypes.Profile) {
+	require.NotNil(t, profile.Modify)
+	require.NotNil(t, profile.Modify.Alters)
+	alterations := *profile.Modify.Alters
+	require.NotNil(t, alterations[0].Adds)
+	require.Greater(t, len(*alterations[0].Adds), 0)
+
+	firstAddition := (*alterations[0].Adds)[0]
+	require.NotNil(t, firstAddition.Parts)
+	parts := *firstAddition.Parts
+
+	assert.GreaterOrEqual(t, len(parts), 2, "Merged parts should have parts from both guidelines")
+	hasFirstStatement := false
+	hasSecondStatement := false
+	for _, part := range parts {
+		if part.Name == "statement" && part.Parts != nil {
+			for _, subPart := range *part.Parts {
+				if subPart.Prose == "First statement" {
+					hasFirstStatement = true
+				}
+				if subPart.Prose == "Second statement" {
+					hasSecondStatement = true
+				}
+			}
+		}
 	}
-	var l1Docs gemara.GuidanceDocument
-	if err := yaml.Unmarshal(data, &l1Docs); err != nil {
-		return gemara.GuidanceDocument{}, err
-	}
-	return l1Docs, nil
+	assert.True(t, hasFirstStatement, "First statement should be present in merged parts")
+	assert.True(t, hasSecondStatement, "Second statement should be present in merged parts")
 }

--- a/oscal/test-data.go
+++ b/oscal/test-data.go
@@ -1,0 +1,187 @@
+package oscal
+
+import (
+	"os"
+
+	"github.com/goccy/go-yaml"
+	"github.com/ossf/gemara"
+)
+
+func goodAIGFExample() (gemara.GuidanceDocument, error) {
+	testdataPath := "../test-data/good-aigf.yaml"
+	data, err := os.ReadFile(testdataPath)
+	if err != nil {
+		return gemara.GuidanceDocument{}, err
+	}
+	var l1Docs gemara.GuidanceDocument
+	if err := yaml.Unmarshal(data, &l1Docs); err != nil {
+		return gemara.GuidanceDocument{}, err
+	}
+	return l1Docs, nil
+}
+
+// guidanceWithExternalExtends returns a guidance document with a guideline that extends an external control.
+func guidanceWithExternalExtends() gemara.GuidanceDocument {
+	return gemara.GuidanceDocument{
+		Title: "Test Guidance",
+		Metadata: gemara.Metadata{
+			Id:      "TEST-GUIDE",
+			Version: "1.0.0",
+			Author: gemara.Actor{
+				Id:   "test-author",
+				Name: "Test Author",
+				Type: gemara.Human,
+			},
+			MappingReferences: []gemara.MappingReference{
+				{
+					Id:      "NIST-800-53",
+					Title:   "NIST SP 800-53",
+					Version: "Rev 5",
+					Url:     "https://nist.gov/800-53",
+				},
+			},
+		},
+		DocumentType: gemara.DocumentType("Framework"),
+		Families: []gemara.Family{
+			{
+				Id:          "AC",
+				Title:       "Access Control",
+				Description: "Access control family",
+			},
+		},
+		Guidelines: []gemara.Guideline{
+			{
+				Id:     "TEST-AC-1",
+				Title:  "Test Access Control Enhancement",
+				Family: "AC",
+				Extends: &gemara.SingleMapping{
+					ReferenceId: "NIST-800-53",
+					EntryId:     "AC-1",
+				},
+				Objective: "Enhanced access control policy",
+				Statements: []gemara.Statement{
+					{
+						Id:   "1",
+						Text: "Additional requirement for access control",
+					},
+				},
+			},
+		},
+	}
+}
+
+// guidanceWithMerging returns a guidance document with multiple guidelines extending the same external control.
+func guidanceWithMerging() gemara.GuidanceDocument {
+	return gemara.GuidanceDocument{
+		Title: "Test Guidance",
+		Metadata: gemara.Metadata{
+			Id:      "TEST-GUIDE",
+			Version: "1.0.0",
+			Author: gemara.Actor{
+				Id:   "test-author",
+				Name: "Test Author",
+				Type: gemara.Human,
+			},
+			MappingReferences: []gemara.MappingReference{
+				{
+					Id:      "NIST-800-53",
+					Title:   "NIST SP 800-53",
+					Version: "Rev 5",
+					Url:     "https://nist.gov/800-53",
+				},
+			},
+		},
+		DocumentType: gemara.DocumentType("Framework"),
+		Families: []gemara.Family{
+			{
+				Id:          "AC",
+				Title:       "Access Control",
+				Description: "Access control family",
+			},
+		},
+		Guidelines: []gemara.Guideline{
+			{
+				Id:     "TEST-AC-1",
+				Title:  "First Enhancement for AC-1",
+				Family: "AC",
+				Extends: &gemara.SingleMapping{
+					ReferenceId: "NIST-800-53",
+					EntryId:     "AC-1",
+				},
+				Objective: "First objective",
+				Statements: []gemara.Statement{
+					{
+						Id:   "1",
+						Text: "First statement",
+					},
+				},
+			},
+			{
+				Id:     "TEST-AC-1-2",
+				Title:  "Second Enhancement for AC-1",
+				Family: "AC",
+				Extends: &gemara.SingleMapping{
+					ReferenceId: "NIST-800-53",
+					EntryId:     "AC-1",
+				},
+				Statements: []gemara.Statement{
+					{
+						Id:   "2",
+						Text: "Second statement",
+					},
+				},
+			},
+		},
+	}
+}
+
+// guidanceWithLocalExtends returns a guidance document with a guideline that extends another guideline in the same document.
+func guidanceWithLocalExtends() gemara.GuidanceDocument {
+	return gemara.GuidanceDocument{
+		Title: "Test Guidance",
+		Metadata: gemara.Metadata{
+			Id:      "TEST-GUIDE",
+			Version: "1.0.0",
+			Author: gemara.Actor{
+				Id:   "test-author",
+				Name: "Test Author",
+				Type: gemara.Human,
+			},
+		},
+		DocumentType: gemara.DocumentType("Framework"),
+		Families: []gemara.Family{
+			{
+				Id:          "AC",
+				Title:       "Access Control",
+				Description: "Access control family",
+			},
+		},
+		Guidelines: []gemara.Guideline{
+			{
+				Id:     "TEST-AC-1",
+				Title:  "Base Access Control",
+				Family: "AC",
+			},
+			{
+				Id:     "TEST-AC-1-ENH",
+				Title:  "Enhanced Access Control",
+				Family: "AC",
+				Extends: &gemara.SingleMapping{
+					EntryId: "TEST-AC-1",
+				},
+			},
+		},
+	}
+}
+
+// guidanceWithImports returns a copy of the provided guidance document with an additional mapping reference added.
+func guidanceWithImports(base gemara.GuidanceDocument) gemara.GuidanceDocument {
+	mapping := gemara.MappingReference{
+		Id:          "EXP",
+		Description: "Example",
+		Version:     "0.1.0",
+		Url:         "https://example.com",
+	}
+	base.Metadata.MappingReferences = append(base.Metadata.MappingReferences, mapping)
+	return base
+}

--- a/oscal/test-data.go
+++ b/oscal/test-data.go
@@ -174,6 +174,65 @@ func guidanceWithLocalExtends() gemara.GuidanceDocument {
 	}
 }
 
+// guidanceWithMultiLevelNested returns a guidance document with multi-level nested local extensions (AC-1 -> AC-1-ENH -> AC-1-ENH-2).
+func guidanceWithMultiLevelNested() gemara.GuidanceDocument {
+	return gemara.GuidanceDocument{
+		Title: "Test Guidance",
+		Metadata: gemara.Metadata{
+			Id:      "TEST-GUIDE",
+			Version: "1.0.0",
+			Author: gemara.Actor{
+				Id:   "test-author",
+				Name: "Test Author",
+				Type: gemara.Human,
+			},
+		},
+		DocumentType: gemara.DocumentType("Framework"),
+		Families: []gemara.Family{
+			{
+				Id:    "AC",
+				Title: "Access Control",
+			},
+		},
+		Guidelines: []gemara.Guideline{
+			{
+				Id:       "AC-1",
+				Title:    "Base Control",
+				Family:   "AC",
+				Objective: "Base control objective",
+			},
+			{
+				Id:     "AC-1-ENH",
+				Title:  "First Enhancement",
+				Family: "AC",
+				Extends: &gemara.SingleMapping{
+					EntryId: "AC-1",
+				},
+				Statements: []gemara.Statement{
+					{
+						Id:   "1",
+						Text: "First enhancement statement",
+					},
+				},
+			},
+			{
+				Id:     "AC-1-ENH-2",
+				Title:  "Second Enhancement",
+				Family: "AC",
+				Extends: &gemara.SingleMapping{
+					EntryId: "AC-1-ENH",
+				},
+				Statements: []gemara.Statement{
+					{
+						Id:   "1",
+						Text: "Second enhancement statement",
+					},
+				},
+			},
+		},
+	}
+}
+
 // guidanceWithImports returns a copy of the provided guidance document with an additional mapping reference added.
 func guidanceWithImports(base gemara.GuidanceDocument) gemara.GuidanceDocument {
 	mapping := gemara.MappingReference{

--- a/schemas/layer-1.cue
+++ b/schemas/layer-1.cue
@@ -6,48 +6,30 @@ package schemas
 @go(gemara)
 
 #GuidanceDocument: {
-	metadata?:       #Metadata @go(Metadata)
 	title:           string
+	metadata:        #Metadata     @go(Metadata)
 	"document-type": #DocumentType @go(DocumentType) @yaml("document-type")
-	exemptions?: [...#Exemption] @go(Exemptions)
-
 	// Introductory text for the document to be used during rendering
 	"front-matter"?: string @go(FrontMatter) @yaml("front-matter,omitempty")
+
 	families?: [...#Family] @go(Families)
 	guidelines?: [...#Guideline] @go(Guidelines)
-
-	// For inheriting from other guidance documents to create tailored documents/baselines
-	"imported-guidelines"?: [...#MultiMapping] @go(ImportedGuidelines) @yaml("imported-guidelines,omitempty")
-	"imported-principles"?: [...#MultiMapping] @go(ImportedPrinciples) @yaml("imported-principles,omitempty")
+	exemptions?: [...#Exemption] @go(Exemptions)
 }
 
 #DocumentType: "Standard" | "Regulation" | "Best Practice" | "Framework"
 
-// Exemption represents an exemption with a reason and optional redirect
+// Exemption represents those who are exempt from the full guidance document.
 #Exemption: {
-	reason:    string
-	redirect?: #MultiMapping @go(Redirect)
-}
-
-// Rationale provides contextual information to help with development and understanding of
-// guideline intent.
-#Rationale: {
-	// Negative results expected from the guideline's lack of implementation
-	risks: [...#Risk]
-	// Positive results expected from the guideline's implementation
-	outcomes: [...#Outcome]
-}
-
-#Risk: {
-	title:       string
+	// Description identifies who or what is exempt from the full guidance
 	description: string
+	// Reason explains why the exemption is granted
+	reason: string
+	// Redirect points to alternative guidelines or controls that should be followed instead
+	redirect?: #MultiMapping @go(Redirect,optional=nillable)
 }
 
-#Outcome: {
-	title:       string
-	description: string
-}
-
+// Guideline represents a single guideline within a guidance document
 #Guideline: {
 	id:         string
 	title:      string
@@ -59,27 +41,36 @@ package schemas
 	// Maps to fields commonly seen in controls with implementation guidance
 	recommendations?: [...string]
 
-	// For control enhancements (ex. AC-2(1) in 800-53)
-	// The base-guideline-id is needed to achieve full context for the enhancement
-	"base-guideline-id"?: string @go(BaseGuidelineID) @yaml("base-guideline-id,omitempty")
+	// Extends allows you to add supplemental guidance within a local guidance document
+	// like a control enhancement or from an imported guidance document.
+	extends?: #SingleMapping @go(Extends,optional=nillable)
+
+	// Applicability specifies the contexts in which this guideline applies.
+	applicability?: [...string] @go(Applicability)
 
 	rationale?: #Rationale @go(Rationale,optional=nillable)
+	statements?: [...#Statement] @go(Statements)
 
-	// Represents individual guideline parts/statements
-	"guideline-parts"?: [...#Part] @go(GuidelineParts) @yaml("guideline-parts,omitempty")
-	// Crosswalking this guideline to other guidelines in other documents
 	"guideline-mappings"?: [...#MultiMapping] @go(GuidelineMappings) @yaml("guideline-mappings,omitempty")
 	// A list for associated key principle ids
 	"principle-mappings"?: [...#MultiMapping] @go(PrincipleMappings) @yaml("principle-mappings,omitempty")
 
-	// This is akin to related controls, but using more explicit terminology
+	// SeeAlso lists related guideline IDs within the same Guidance document.
 	"see-also"?: [...string] @go(SeeAlso) @yaml("see-also,omitempty")
 }
 
-// Parts include sub-statements of a guideline that can be assessed individually
-#Part: {
+// Statement represents a structural sub-requirement within a guideline
+// They do not increase strictness and all statements within a guideline apply together.
+#Statement: {
 	id:     string
 	title?: string
 	text:   string
 	recommendations?: [...string]
+}
+
+// Rationale provides contextual information to help with development and understanding of
+// guideline intent.
+#Rationale: {
+	importance: string
+	goals: [...string]
 }

--- a/schemas/layer-1.cue
+++ b/schemas/layer-1.cue
@@ -15,6 +15,18 @@ package schemas
 	families?: [...#Family] @go(Families)
 	guidelines?: [...#Guideline] @go(Guidelines)
 	exemptions?: [...#Exemption] @go(Exemptions)
+
+	// Guidelines that extend other guidelines must be in the same family as the
+	// extended guideline.
+	_validateExtensions: {
+		for guideline in guidelines if guideline.extends != _|_ {
+			if (guideline.extends."reference-id" == "" || guideline.extends."reference-id" == _|_) {
+				for extended in guidelines if extended.id == guideline.extends."entry-id" {
+					guideline.family == extended.family
+				}
+			}
+		}
+	}
 }
 
 #DocumentType: "Standard" | "Regulation" | "Best Practice" | "Framework"

--- a/test-data/good-aigf.yaml
+++ b/test-data/good-aigf.yaml
@@ -30,11 +30,10 @@ guidelines:
     title: Human Feedback Loop for AI Systems
     objective: A Human Feedback Loop is a critical detective and continuous improvement mechanism that involves systematically collecting, analyzing, and acting upon feedback provided by human users, subject matter experts (SMEs), or reviewers regarding an AI system's performance, outputs, or behavior.
     rationale:
-      risks: []
-      outcomes:
-        - title: Governance Support
-          description: Provides data for AI governance bodies to monitor impact and make decisions
-    guideline-parts:
+      importance: A Human Feedback Loop is critical for ensuring AI systems operate effectively and safely by incorporating human judgment and expertise into continuous improvement processes.
+      goals:
+        - "Governance Support: Provides data for AI governance bodies to monitor impact and make decisions"
+    statements:
       - id: AIR-DET-011.1
         title: Designing the Feedback Mechanism
         text: Implementing an effective human feedback loop involves careful design of the mechanism.
@@ -78,19 +77,19 @@ guidelines:
     title: Example Detective Control 004
     objective: Placeholder control for testing references.
     rationale:
-      risks: []
-      outcomes: []
+      importance: Placeholder control for testing references.
+      goals: []
   - id: AIR-DET-015
     family: DET
     title: Example Detective Control 015
     objective: Placeholder control for testing references.
     rationale:
-      risks: []
-      outcomes: []
+      importance: Placeholder control for testing references.
+      goals: []
   - id: AIR-PREV-005
     family: PREV
     title: Example Preventive Control 005
     objective: Placeholder control for testing references.
     rationale:
-      risks: []
-      outcomes: []
+      importance: Placeholder control for testing references.
+      goals: []


### PR DESCRIPTION
## Description

This PR applies feedback to Layer 1

### Level Setting

**Possible Lexicon Adds**

Exemption - A structural exclusion where guidance is deemed inapplicable to a target.

### Goals

`Extends`: What guidelines are being supplemented by this guideline? Are they local to this guidance or do they exist in another guidance document? When are these additional guidelines applicable?

> Removed `imported-guidelines` and `imported-principles`: Any imported principles should be through the `Extends` for adding supplemental guidance.
> `BaseGuidelineId` - Local and External Supplemental Guideline or extensions (e.g. control enhancements) are handled through Extends

`Exemptions`: In what use cases or scenarios does this guidance not apply? Why does it not apply? Is there alternate guidance that should be followed?

`Rationale`: What is the intent behind the guideline and its value proposition? What positive outcomes are trying to be achieved?

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [X] Layer 1 schema (`schemas/layer-1.cue`) changes
- [ ] Layer 2 schema (`schemas/layer-2.cue`) changes
- [ ] Layer 3 schema (`schemas/layer-3.cue`) changes
- [ ] Layer 4 schema (`schemas/layer-4.cue`) changes

See Reviewer Hints

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [X] Unit tests added/updated
- [ ] Manual testing performed
- [X] Test data updated (if applicable)

## Related Issues

Continuation of #204 

## Reviewer Hints

Extensions from imported catalogs are treated as OSCAL Profile alteration `Adds`

**Examples**:

```
guidelines:
  - id: "CLOUD-AC-1"
    title: "Access Control Policy and Procedures | Cloud Requirements"
    family: "AC"
    extends:
      reference-id: "NIST-800-53"
      entry-id: "AC-1"
    applicability:
      - "cloud"
    objective: "Extend access control policy requirements for cloud environments."
    recommendations:
      - "Access control policies should be reviewed and updated at least annually or when significant changes occur in the cloud environment."
```

```
guidelines:
  # Base control AU-1: Audit Policy
  - id: "AU-1"
    title: "Audit Policy"
    family: "AU"
    objective: "Establish and maintain an audit policy that defines audit requirements and procedures."
    statements:
      - id: "a"
        text: "Develop and document an audit policy that addresses purpose, scope, roles, responsibilities, and compliance requirements."
      - id: "b"
        text: "Disseminate the audit policy to all personnel with access to organizational systems."
      - id: "c"
        text: "Review and update the audit policy periodically or when significant changes occur."
    recommendations:
      - "Audit policies should align with organizational risk management strategies."

  # Enhancement AU-1.1: Continuous Auditing (extends AU-1 locally)
  # This enhancement applies to higher impact systems
  - id: "AU-1.1"
    title: "Audit Policy | Continuous Auditing"
    family: "AU"
    extends:
      entry-id: "AU-1"  # Local extension
    applicability:
      - "high-impact"
    objective: "Implement continuous auditing capabilities for real-time monitoring and detection."
    statements:
      - id: "a"
        text: "Implement automated audit log collection and analysis systems."
      - id: "b"
        text: "Configure real-time alerting for critical security events."
      - id: "c"
        text: "Establish procedures for responding to audit alerts and anomalies."
      - id: "d"
        text: "Review and tune audit alerting thresholds based on organizational risk."
    recommendations:
      - "Continuous auditing systems should integrate with security information and event management (SIEM) tools."
      - "Organizations should define clear escalation procedures for audit alerts."
```