### PR TITLE
fix: marks reference-id as required on imports

### DIFF
--- a/generated_types.go
+++ b/generated_types.go
@@ -424,7 +424,7 @@ type Imports struct {
 
 // CatalogImport defines how to import control catalogs with optional exclusions, constraints, and assessment requirement modifications.
 type CatalogImport struct {
-	ReferenceId string `json:"reference-id,omitempty" yaml:"reference-id,omitempty"`
+	ReferenceId string `json:"reference-id" yaml:"reference-id"`
 
 	Exclusions []string `json:"exclusions,omitempty" yaml:"exclusions,omitempty"`
 
@@ -470,7 +470,7 @@ type ModType string
 
 // GuidanceImport defines how to import guidance documents with optional exclusions and constraints.
 type GuidanceImport struct {
-	ReferenceId string `json:"reference-id,omitempty" yaml:"reference-id,omitempty"`
+	ReferenceId string `json:"reference-id" yaml:"reference-id"`
 
 	Exclusions []string `json:"exclusions,omitempty" yaml:"exclusions,omitempty"`
 

--- a/schemas/layer-3.cue
+++ b/schemas/layer-3.cue
@@ -122,7 +122,7 @@ package schemas
 
 // GuidanceImport defines how to import guidance documents with optional exclusions and constraints.
 #GuidanceImport: {
-	"reference-id"?: string @go(ReferenceId)
+	"reference-id": string @go(ReferenceId)
 	exclusions?: [...string]
 	// Constraints allow policy authors to define ad hoc minimum requirements (e.g., "review at least annually").
 	constraints?: [...#Constraint]
@@ -130,7 +130,7 @@ package schemas
 
 // CatalogImport defines how to import control catalogs with optional exclusions, constraints, and assessment requirement modifications.
 #CatalogImport: {
-	"reference-id"?: string @go(ReferenceId)
+	"reference-id": string @go(ReferenceId)
 	exclusions?: [...string]
 	constraints?: [...#Constraint]
 	"assessment-requirement-modifications"?: [...#AssessmentRequirementModifier] @go(AssessmentRequirementModifications)


### PR DESCRIPTION


## Description

This PR updates Layer 3 Policy to required `reference-id` on imports. Imports should required references to the imported content.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [ ] Layer 1 schema (`schemas/layer-1.cue`) changes
- [ ] Layer 2 schema (`schemas/layer-2.cue`) changes
- [X] Layer 3 schema (`schemas/layer-3.cue`) changes
- [ ] Layer 4 schema (`schemas/layer-4.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

`reference-id` on `GuidanceImport` and `CatalogImport` went from optional to required.

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->
