### PR TITLE
ci: Update token secret in baseline-scanner workflow

### DIFF
--- a/.github/workflows/baseline-scanner.yml
+++ b/.github/workflows/baseline-scanner.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           owner: ${{ github.repository_owner }}
           repo: ${{ github.event.repository.name }}
-          token: ${{ secrets.PVTR_GITHUB_TOKEN }}
+          token: ${{ secrets.GH_AUTH_TOKEN }}
           catalog: "osps-baseline"
           upload-sarif: "true"
 


### PR DESCRIPTION
The token currently used in CI was expired or removed. [Logs here](https://github.com/ossf/gemara/actions/runs/20710428678/job/59449513765#step:3:107)

Changing to use the name from the Scorecard repo worked ran as recently as this morning. [Logs here](https://github.com/ossf/scorecard/blob/525a93017816fa74238c545bdecac6af16ce00f1/.github/workflows/osps-baseline.yml#L21)