### PR TITLE
feat!: updates mapping strength to be optional

### DIFF
--- a/generated_types.go
+++ b/generated_types.go
@@ -157,7 +157,9 @@ type MultiMapping struct {
 type MappingEntry struct {
 	ReferenceId string `json:"reference-id" yaml:"reference-id"`
 
-	Strength int64 `json:"strength" yaml:"strength"`
+	// Strength quantifies the degree of correlation or relationship between the mapped items.
+	// Range: 1-10. Zero value means not yet quantified.
+	Strength int64 `json:"strength,omitempty" yaml:"strength,omitempty"`
 
 	Remarks string `json:"remarks,omitempty" yaml:"remarks,omitempty"`
 }

--- a/schemas/mapping.cue
+++ b/schemas/mapping.cue
@@ -35,6 +35,8 @@ package schemas
 // MappingEntry represents a single entry within a mapping
 #MappingEntry: {
 	"reference-id": string @go(ReferenceId)
-	strength:       int & >=1 & <=10
-	remarks?:       string
+	// Strength quantifies the degree of correlation or relationship between the mapped items.
+	// Range: 1-10. Zero value means not yet quantified.
+	strength?: int & >=1 & <=10
+	remarks?:  string
 }


### PR DESCRIPTION
## Description

This PR updates strength to optional on `MultiMapping`. Requiring strength on `MultiMapping` adds friction during initial usage possible forcing a quantification of strength when the mapping is qualitative or binary.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [X] Layer 1 schema (`schemas/layer-1.cue`) changes
- [X] Layer 2 schema (`schemas/layer-2.cue`) changes
- [X] Layer 3 schema (`schemas/layer-3.cue`) changes
- [X] Layer 4 schema (`schemas/layer-4.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

`strength` is is optional on `MappingEntry`

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [X] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->
