### PR TITLE
ci: remove pull_request_target trigger from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,9 +2,6 @@
 name: "Release"
 on:
   workflow_dispatch:
-  pull_request_target:
-    types: [closed]
-    branches: [main]
 jobs:
   release:
     permissions:


### PR DESCRIPTION
## Description

Let's remove automated releases for every feature merge to main temporarily until we cut a v1 release.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [X] No schema changes
- [ ] Layer 1 schema (`schemas/layer-1.cue`) changes
- [ ] Layer 2 schema (`schemas/layer-2.cue`) changes
- [ ] Layer 3 schema (`schemas/layer-3.cue`) changes
- [ ] Layer 4 schema (`schemas/layer-4.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->

We can still create releases using `workflow_dispatch` if we need to
