### PR TITLE
docs: adds adr0007 to document Go code migration decision

### DIFF
--- a/docs/adr/0006-unified-package-structure.md
+++ b/docs/adr/0006-unified-package-structure.md
@@ -5,7 +5,7 @@ title: Unified Go SDK Package Structure
 
 - **ADR:** 0006
 - **Proposal Author(s):** @jpower432
-- **Status:** Accepted
+- **Status:** Accepted; Modified by ADR 0007
 
 ## Context
 

--- a/docs/adr/0007-isolate-concepts-from-code.md
+++ b/docs/adr/0007-isolate-concepts-from-code.md
@@ -1,0 +1,37 @@
+---
+layout: page
+title: Isolate Concepts from Code
+---
+
+- **ADR:** 0007
+- **Proposal Author(s):** @eddie-knight, @jpower432
+- **Status:** Accepted
+
+## Context
+
+While [ADR-0006](./0006-unified-package-structure.md) served to simplify the Go SDK for
+developer users, added cognitive overhead was observed for visitors to the project repo,
+caused by the large number of Go files. The project had begun to appear as if it is
+primarily a software project, rather than a specification project with support utilities.
+
+Additionally, the previous implementation of ADR-0006 did not account for SDKs in other
+languages beyond Go, which is highly likely if Gemara evolves like other similar projects.
+
+## Decision
+
+All SDK code should be hosted in secondary repositories.
+
+## Consequences
+
+Complexity on first move — this will delay us a bit on our pursuit toward v1.
+
+Lowered complexity over time — schema changes can be incremental, and SDK doesn't need to
+be updated until a schema release is made.
+
+No additional overhead needed to manage the release processes and versioning for the schemas and different SDKs.
+
+SDKs can be adjusted to support multiple schema versions if needed later.
+
+## Alternatives Considered
+
+We could create a /go or /sdk subdirectory instead. We'd then use the website, language-specific package repositories, and some CI magic to handle the release cycles for the different types of assets.


### PR DESCRIPTION
## Description

This adds the ADR to document the decision to migrate Go code to `go-gemara` via #256 

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [X] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [ ] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 4 schema (`layer-4.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->
