### PR TITLE
ci: updates release pipeline to use tag from release drafter

### DIFF
--- a/.github/actions/validate-cue/action.yml
+++ b/.github/actions/validate-cue/action.yml
@@ -15,6 +15,10 @@ runs:
       with:
         version: ${{ inputs.cue-version }}
 
+    - name: Check CUE module tidiness
+      run: make tidycheck
+      shell: bash
+
     - name: Validate the formatting of cue schema files
       run: make cuefmtcheck
       shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,10 +13,10 @@ jobs:
       release-config-name: release-drafter.yml
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}
-  publish-cue-module:
+  publish-cue:
     needs: release
+    if: needs.release.outputs.full-tag != ''
     runs-on: ubuntu-latest
-    if: startsWith(github.ref_name, 'v')
     permissions:
       contents: read
     steps:
@@ -32,4 +32,4 @@ jobs:
       - name: Login to Central Registry
         run: cue login --token=${{ secrets.CUE_REG_TOKEN }}
       - name: Publish the module
-        run: cue mod publish ${{ github.ref_name }}
+        run: cue mod publish ${{ needs.release.outputs.full-tag }}

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,16 @@ tidy:
 	@echo "  >  Tidying cue.mod ..."
 	@cue mod tidy
 
+tidycheck: tidy
+	@echo "  >  Checking CUE module tidiness ..."
+	@if [ -n "$$(git status --porcelain cue.mod 2>/dev/null)" ]; then \
+		echo "Error: cue.mod is not tidy. Please run 'make tidy' and commit the changes."; \
+		git diff cue.mod; \
+		exit 1; \
+	fi
+	@echo "  >  CUE module is tidy."
+
+
 # Verify CUE formatting
 cuefmtcheck:
 	@echo "  >  Verifying CUE formatting ..."
@@ -48,4 +58,4 @@ stop:
 
 restart: stop serve
 
-.PHONY: tidy cuefmtcheck lintcue lintinsights serve build clean stop restart check-jekyll
+.PHONY: tidy tidycheck cuefmtcheck lintcue lintinsights serve build clean stop restart check-jekyll


### PR DESCRIPTION
## Description

This PR updates the CUE release workflow:
- Adds CUE module tidiness check
- Removes requirement to run on a tag. The release-drafter job returns a tag.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [X] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [ ] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 4 schema (`layer-4.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [X] Manual testing performed - On my fork
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->
