### PR TITLE
docs: add html-proofer and remove html extension in cross-site links

### DIFF
--- a/.github/workflows/jekyll-site.yml
+++ b/.github/workflows/jekyll-site.yml
@@ -46,6 +46,13 @@ jobs:
         id: pages
         uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5.0.0
 
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+          working-directory: ./docs
+
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.13
         with:
@@ -53,15 +60,7 @@ jobs:
           destination: ./docs/_site
 
       - name: Test HTML
-        run: |
-          # Check that key pages were generated
-          echo "Verifying generated pages..."
-          test -f docs/_site/index.html || { echo "Error: Missing index.html"; exit 1; }
-          test -f docs/_site/lexicon/lexicon.html || { echo "Error: Missing lexicon.html"; exit 1; }
-          # Verify sidebar is included in pages that should have it (not homepage)
-          grep -q "Quick Links" docs/_site/lexicon/lexicon.html || { echo "Error: Sidebar not found in lexicon.html"; exit 1; }
-          grep -q "Quick Links" docs/_site/adr.html || { echo "Error: Sidebar not found in adr.html"; exit 1; }
-          echo "Success: All expected pages generated successfully"
+        run: make test-links
 
       - name: Upload artifact for GitHub Pages
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/Makefile
+++ b/Makefile
@@ -48,6 +48,16 @@ build: check-jekyll
 	@echo "  >  Building Jekyll documentation site..."
 	@cd docs && bundle exec jekyll build
 
+test-links:
+	@echo "  >  Validating links with html-proofer..."
+	@cd docs && bundle exec htmlproofer _site \
+		--allow-hash-href \
+		--disable-external \
+		--ignore-empty-alt \
+		--only-4xx \
+		--root-dir "$$(pwd)/_site" \
+		--ignore-urls "/localhost/,/0.0.0.0/,/127.0.0.1/,/\/pages\//"
+
 clean:
 	@echo "  >  Cleaning generated files..."
 	@rm -rf docs/_site docs/.jekyll-cache docs/.jekyll-metadata
@@ -58,4 +68,4 @@ stop:
 
 restart: stop serve
 
-.PHONY: tidy tidycheck cuefmtcheck lintcue lintinsights serve build clean stop restart check-jekyll
+.PHONY: tidy tidycheck cuefmtcheck lintcue lintinsights serve build test-links clean stop restart check-jekyll

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 
 # Specify minimum Ruby version
-ruby ">= 3.0.0"
+ruby ">= 3.2.0"
 
 # Jekyll version
 gem "jekyll", "~> 4.4.1"
@@ -19,6 +19,11 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "jekyll-seo-tag", "~> 2.8"
   gem "jekyll-remote-theme", "~> 0.4"
+end
+
+# Development and testing tools
+group :development, :test do
+  gem "html-proofer", "~> 5.0"
 end
 
 # Platform-specific gems

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -1,16 +1,31 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    Ascii85 (2.0.1)
     addressable (2.8.8)
       public_suffix (>= 2.0.2, < 8.0)
+    afm (1.0.0)
+    async (2.36.0)
+      console (~> 1.29)
+      fiber-annotation
+      io-event (~> 1.11)
+      metrics (~> 0.12)
+      traces (~> 0.18)
     base64 (0.3.0)
+    benchmark (0.5.0)
     bigdecimal (3.3.1)
     colorator (1.1.0)
     concurrent-ruby (1.3.5)
+    console (1.34.2)
+      fiber-annotation
+      fiber-local (~> 1.1)
+      json
     csv (3.3.5)
     em-websocket (0.5.3)
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0)
+    ethon (0.15.0)
+      ffi (>= 1.15.0)
     eventmachine (1.2.7)
     ffi (1.17.2)
     ffi (1.17.2-aarch64-linux-gnu)
@@ -23,6 +38,10 @@ GEM
     ffi (1.17.2-x86_64-darwin)
     ffi (1.17.2-x86_64-linux-gnu)
     ffi (1.17.2-x86_64-linux-musl)
+    fiber-annotation (0.2.0)
+    fiber-local (1.1.0)
+      fiber-storage
+    fiber-storage (1.0.1)
     forwardable-extended (2.6.0)
     google-protobuf (4.33.2)
       bigdecimal
@@ -51,9 +70,21 @@ GEM
     google-protobuf (4.33.2-x86_64-linux-musl)
       bigdecimal
       rake (>= 13)
+    hashery (2.1.2)
+    html-proofer (5.2.0)
+      addressable (~> 2.3)
+      async (~> 2.1)
+      benchmark (~> 0.5)
+      nokogiri (~> 1.13)
+      pdf-reader (~> 2.11)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
+      zeitwerk (~> 2.5)
     http_parser.rb (0.8.0)
     i18n (1.14.7)
       concurrent-ruby (~> 1.0)
+    io-event (1.14.2)
     jekyll (4.4.1)
       addressable (~> 2.4)
       base64 (~> 0.2)
@@ -97,19 +128,49 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     logger (1.7.0)
     mercenary (0.4.0)
+    metrics (0.15.0)
+    mini_portile2 (2.8.9)
     minima (2.5.2)
       jekyll (>= 3.5, < 5.0)
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
+    nokogiri (1.19.0)
+      mini_portile2 (~> 2.8.2)
+      racc (~> 1.4)
+    nokogiri (1.19.0-aarch64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-aarch64-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm-linux-musl)
+      racc (~> 1.4)
+    nokogiri (1.19.0-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.19.0-x86_64-linux-musl)
+      racc (~> 1.4)
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
+    pdf-reader (2.15.1)
+      Ascii85 (>= 1.0, < 3.0, != 2.0.0)
+      afm (>= 0.2.1, < 2)
+      hashery (~> 2.0)
+      ruby-rc4
+      ttfunk
     public_suffix (6.0.2)
+    racc (1.8.1)
+    rainbow (3.1.1)
     rake (13.3.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
     rexml (3.4.4)
     rouge (4.6.1)
+    ruby-rc4 (0.1.5)
     rubyzip (2.4.1)
     safe_yaml (1.0.5)
     sass-embedded (1.94.2)
@@ -145,8 +206,15 @@ GEM
       google-protobuf (~> 4.31)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
+    traces (0.18.2)
+    ttfunk (1.8.0)
+      bigdecimal (~> 3.1)
+    typhoeus (1.5.0)
+      ethon (>= 0.9.0, < 0.16.0)
     unicode-display_width (2.6.0)
     webrick (1.9.2)
+    yell (2.2.2)
+    zeitwerk (2.7.4)
 
 PLATFORMS
   aarch64-linux-android
@@ -172,6 +240,7 @@ PLATFORMS
 DEPENDENCIES
   base64
   csv
+  html-proofer (~> 5.0)
   http_parser.rb (~> 0.6.0)
   jekyll (~> 4.4.1)
   jekyll-feed (~> 0.12)
@@ -184,7 +253,7 @@ DEPENDENCIES
   wdm (~> 0.1)
 
 RUBY VERSION
-   ruby 3.1.1p18
+   ruby 3.4.8p72
 
 BUNDLED WITH
    2.6.9

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,11 +1,11 @@
 - title: Home
   url: /
 - title: The Model
-  url: /model.html
+  url: /model/
 - title: Roadmap
-  url: /roadmap.html
+  url: /roadmap/
 - title: ADRs
-  url: /adr.html
+  url: /adr/
 - title: Community
-  url: /community/index.html
+  url: /community/
   

--- a/docs/_includes/footer.html
+++ b/docs/_includes/footer.html
@@ -36,7 +36,7 @@
     <div class="footer-copyright">
         Copyright © Gemara contributors, a Series of LF Projects, LLC.
         For website terms of use, trademark policy, and other project policies please see <a href="https://lfprojects.org">https://lfprojects.org</a>.
-        This site is open source. View or contribute at <a href="{{ site.github.repository_url }}">GitHub</a>.
+        This site is open source. View or contribute at <a href="{% if site.github.repository_url %}{{ site.github.repository_url }}{% else %}https://github.com/{{ site.repository }}{% endif %}">GitHub</a>.
     </div>
 
   </div>

--- a/docs/adrs/0001-logical-model.md
+++ b/docs/adrs/0001-logical-model.md
@@ -5,7 +5,7 @@ title: Create A Logical Model for GRC Engineering Activities
 
 - **ADR:** 0001
 - **Proposal Author(s):** @eddie-knight
-- **Status:** Accepted; Modified by [ADR-0009](./0009-sensitive-activities.md) (layer numbers)
+- **Status:** Accepted; Modified by [ADR-0009](./0009-sensitive-activities) (layer numbers)
 
 ## Context
 

--- a/docs/adrs/0002-model-schemas.md
+++ b/docs/adrs/0002-model-schemas.md
@@ -5,7 +5,7 @@ title: Create Schemas for Each Layer in the Logical Model
 
 - **ADR:** 0002
 - **Proposal Author(s):** @eddie-knight
-- **Status:** Accepted; Modified by [ADR-0009](./0009-sensitive-activities.md) (numbering for layers 3+)
+- **Status:** Accepted; Modified by [ADR-0009](./0009-sensitive-activities) (numbering for layers 3+)
 
 ## Context
 

--- a/docs/adrs/0004-go-sdk-layer-4.md
+++ b/docs/adrs/0004-go-sdk-layer-4.md
@@ -5,7 +5,7 @@ title: Extend Go SDK for "Layer 4" Based on the Privateer Project
 
 - **ADR:** 0004
 - **Proposal Author(s):** @eddie-knight
-- **Status:** Accepted; Modified by [ADR-0009](./0009-sensitive-activities.md) (numbering for layers 3+)
+- **Status:** Accepted; Modified by [ADR-0009](./0009-sensitive-activities) (numbering for layers 3+)
 
 ## Context
 

--- a/docs/adrs/0004-go-sdk-layer-4.md
+++ b/docs/adrs/0004-go-sdk-layer-4.md
@@ -5,7 +5,7 @@ title: Extend Go SDK for "Layer 4" Based on the Privateer Project
 
 - **ADR:** 0004
 - **Proposal Author(s):** @eddie-knight
-- **Status:** Accepted; Modified by [ADR-0009](./0009-sensitive-activities) (numbering for layers 3+)
+- **Status:** Accepted; Modified by [ADR-0009](/adrs/0009-sensitive-activities) (numbering for layers 3+)
 
 ## Context
 

--- a/docs/adrs/0006-unified-package-structure.md
+++ b/docs/adrs/0006-unified-package-structure.md
@@ -130,4 +130,4 @@ Create a `common/` package for shared types (e.g., `Metadata`, `Actor`, `Mapping
 
 - [Go Package Design](https://go.dev/blog/package-names)
 - [Effective Go - Packages](https://go.dev/doc/effective_go#names)
-- [Gemara Model Documentation](https://github.com/gemaraproj/gemara/blob/main/README.md#the-model)
+- [Gemara Model Documentation](/model)

--- a/docs/adrs/0006-unified-package-structure.md
+++ b/docs/adrs/0006-unified-package-structure.md
@@ -5,7 +5,7 @@ title: Unified Go SDK Package Structure
 
 - **ADR:** 0006
 - **Proposal Author(s):** @jpower432
-- **Status:** Accepted; Modified by [ADR 0007](./0007-isolate-concepts-from-code.md) (SDK isolation); ; Modified by [ADR-0009](./0009-sensitive-activities.md) (numbering for layers 3+)
+- **Status:** Accepted; Modified by [ADR 0007](./0007-isolate-concepts-from-code) (SDK isolation); ; Modified by [ADR-0009](./0009-sensitive-activities) (numbering for layers 3+)
 
 ## Context
 
@@ -130,4 +130,4 @@ Create a `common/` package for shared types (e.g., `Metadata`, `Actor`, `Mapping
 
 - [Go Package Design](https://go.dev/blog/package-names)
 - [Effective Go - Packages](https://go.dev/doc/effective_go#names)
-- [Gemara Model Documentation](../../README.md#the-model)
+- [Gemara Model Documentation](https://github.com/gemaraproj/gemara/blob/main/README.md#the-model)

--- a/docs/adrs/0007-isolate-concepts-from-code.md
+++ b/docs/adrs/0007-isolate-concepts-from-code.md
@@ -9,7 +9,7 @@ title: Isolate Concepts from Code
 
 ## Context
 
-While [ADR-0006](./0006-unified-package-structure.md) served to simplify the Go SDK for
+While [ADR-0006](./0006-unified-package-structure) served to simplify the Go SDK for
 developer users, added cognitive overhead was observed for visitors to the project repo,
 caused by the large number of Go files. The project had begun to appear as if it is
 primarily a software project, rather than a specification project with support utilities.

--- a/docs/adrs/0012-schema-types.md
+++ b/docs/adrs/0012-schema-types.md
@@ -11,7 +11,7 @@ title: Refine Terms for Top-level Schema Types
 
 We have been organizing schemas based on the layer they fit into — one document per layer. The terms we use for the schema types have been evolving over time and do not successfully achieve consistency and clarity.
 
-Additionally, the model changes from [ADR-0010](./0010-dual-ladder-layers.md) have not all been applied to the latest schemas.
+Additionally, the model changes from [ADR-0010](./0010-dual-ladder-layers) have not all been applied to the latest schemas.
 
 Below are the current top-level types at the time of this proposal:
 

--- a/docs/implementation/index.md
+++ b/docs/implementation/index.md
@@ -93,13 +93,13 @@ The Implementation evolves based on community needs:
 - **Schema improvements?** Open an issue or submit a PR
 - **New features or APIs?** Propose changes via PR
 - **Found a bug?** Report it
-- **Significant architectural changes?** Document in an [ADR](../adr.html)
+- **Significant architectural changes?** Document in an [ADR](/adr)
 
 See the [Contributing Guide](https://github.com/gemaraproj/gemara/blob/main/CONTRIBUTING.md) for details.
 
 ## Architecture Decisions
 
-Significant implementation changes are documented in [Architecture Decision Records (ADRs)](../adr.html).
+Significant implementation changes are documented in [Architecture Decision Records (ADRs)](/adr).
 
 ## Versioning and Maintenance
 
@@ -107,8 +107,8 @@ See the [Implementation Maintenance](maintenance) document for versioning and re
 
 ## Relationship to Other Components
 
-### [The Model](../model)
+### [The Model](/model)
 Provides the conceptual foundation. Each schema corresponds to a layer in the model.
 
-### [The Lexicon](../lexicon)
+### [The Lexicon](/lexicon)
 Informs Implementation design. Schema field names and SDK documentation use Lexicon definitions for consistency.

--- a/docs/lexicon/index.md
+++ b/docs/lexicon/index.md
@@ -6,7 +6,7 @@ title: The Gemara Lexicon
 **Status**: <span class="badge badge-evolving">Evolving</span>
 
 
-While the **[Model](../model)** describes the structure and relationships of GRC activities, the Lexicon provides the vocabulary. It establishes term meanings within the Gemara context, ensuring consistent definitions when teams discuss "controls," "evaluations," or "policies."
+While the **[Model](/model)** describes the structure and relationships of GRC activities, the Lexicon provides the vocabulary. It establishes term meanings within the Gemara context, ensuring consistent definitions when teams discuss "controls," "evaluations," or "policies."
 
 The Lexicon helps teams:
 - **Agree on terminology** across activities and teams
@@ -15,7 +15,7 @@ The Lexicon helps teams:
 
 ## Full Lexicon
 
-**[View the complete lexicon →](./lexicon.html)**
+**[View the complete lexicon →](./lexicon)**
 
 ## Contributing
 
@@ -29,10 +29,10 @@ See the [Contributing Guide](https://github.com/gemaraproj/gemara/blob/main/CONT
 
 ## Relationship to Other Components
 
-### [The Model](../model)
+### [The Model](/model)
 Provides the structural framework. Terms are organized by their relationship to the Model's layers.
 
-### [The Implementation](../implementation)
+### [The Implementation](/implementation)
 Uses Lexicon definitions to inform schema design and SDK documentation. Refer to the Lexicon for precise term meanings.
 
 ## Using the Lexicon

--- a/docs/model.md
+++ b/docs/model.md
@@ -81,6 +81,6 @@ This model is intentionally stable. Changes are rare and require significant com
 
 ## Continue Reading
 
-- **> Next Page**: [Scope](./model/01-scope.html)
+- **> Next Page**: [Scope](/model/01-scope)
 
 ---

--- a/docs/model/01-scope.md
+++ b/docs/model/01-scope.md
@@ -9,7 +9,7 @@ The purpose of this model is to provide a common basis for approaching activitie
 
 ## Continue Reading
 
-- **< Previous Page**: [Introduction to the Model](../model.html)
-- **> Next Page**: [Definitions](./02-definitions.html)
+- **< Previous Page**: [Introduction to the Model](/model)
+- **> Next Page**: [Definitions](/model/02-definitions)
 
 ---

--- a/docs/model/02-definitions.md
+++ b/docs/model/02-definitions.md
@@ -64,7 +64,7 @@ title: Definitions
 
 ## Continue Reading
 
-- **< Previous Page**: [Scope](./01-scope.html)
-- **> Next Page**: [Foundational Concepts](./03-foundational-concepts.html)
+- **< Previous Page**: [Scope](/model/01-scope)
+- **> Next Page**: [Foundational Concepts](/model/03-foundational-concepts)
 
 ---

--- a/docs/model/03-foundational-concepts.md
+++ b/docs/model/03-foundational-concepts.md
@@ -25,7 +25,7 @@ Mirroring the layered approach, the Gemara model defines a contiguous seven-laye
 
 ## Continue Reading
 
-- **< Previous Page**: [Definitions](./02-definitions.html)
-- **> Next Page**: [The Model](./04-the-model.html)
+- **< Previous Page**: [Definitions](/model/02-definitions)
+- **> Next Page**: [The Model](/model/04-the-model)
 
 ---

--- a/docs/model/04-the-model.md
+++ b/docs/model/04-the-model.md
@@ -17,7 +17,7 @@ The model is organized into two primary categories of activity These categories 
 
 Activities in the “definition” layers, one through three, should each produce document assets that may be referenced by higher layers or within their own layer. The “measurement” layers, five through seven, should each produce timestamped logs as outputs.
 
-As noted in [_Foundational Concepts_](./03-foundational-concepts.md), the fourth layer defines sensitive activities connecting the two halves. The first three layers point toward the sensitive activities to define what is "good" and what is "bad". Meanwhile, the last three layers all look back at the sensitive activities — or their outcomes — to determine whether they comply with the definition of good (and in the case of Layer 7: Audit, to also determine the quality of results from all the lower layers). **Figure 4.1** shows these layers in cascading order.
+As noted in [_Foundational Concepts_](./03-foundational-concepts), the fourth layer defines sensitive activities connecting the two halves. The first three layers point toward the sensitive activities to define what is "good" and what is "bad". Meanwhile, the last three layers all look back at the sensitive activities — or their outcomes — to determine whether they comply with the definition of good (and in the case of Layer 7: Audit, to also determine the quality of results from all the lower layers). **Figure 4.1** shows these layers in cascading order.
 
 The rest of this documentation describes each layers with examples.
 
@@ -33,7 +33,7 @@ The rest of this documentation describes each layers with examples.
 
 ## Continue Reading
 
-- **< Previous Page**: - [Foundational Concepts](./03-foundational-concepts.html)
-- **> Next Page**: [The Definition Layers](./05-definition-layers.html)
+- **< Previous Page**: [Foundational Concepts](/model/03-foundational-concepts)
+- **> Next Page**: [The Definition Layers](/model/05-definition-layers)
 
 ---

--- a/docs/model/05-definition-layers.md
+++ b/docs/model/05-definition-layers.md
@@ -21,7 +21,7 @@ As [Goodhart’s law](https://en.wikipedia.org/wiki/Goodhart's_law) teaches us: 
 
 ## Continue Reading
 
-- **< Previous Page**: [The Model](./04-the-model.html)
-- **> Next Page**: [Layer 1](./05.1-Layer-1.html)
+- **< Previous Page**: [The Model](/model/04-the-model)
+- **> Next Page**: [Layer 1](/model/05.1-Layer-1)
 
 ---

--- a/docs/model/05.1-Layer-1.md
+++ b/docs/model/05.1-Layer-1.md
@@ -21,7 +21,7 @@ Vector artifacts can be referenced by both Guidance and Threats to accelerate au
 
 ## Continue Reading
 
-- **< Previous Page**: - [The Definition Layers](./05-definition-layers.html)
-- **> Next Page**: [Layer 2](./05.2-Layer-2.html)
+- **< Previous Page**: [The Definition Layers](/model/05-definition-layers)
+- **> Next Page**: [Layer 2](/model/05.2-Layer-2)
 
 ---

--- a/docs/model/05.2-Layer-2.md
+++ b/docs/model/05.2-Layer-2.md
@@ -28,7 +28,7 @@ The recommended process to create a control catalog for an information system is
 
 ## Continue Reading
 
-- **< Previous Page**: [Layer 1](./05.1-Layer-1.html)
-- **> Next Page**: [Layer 3](./05.3-Layer-3.html)
+- **< Previous Page**: [Layer 1](/model/05.1-Layer-1)
+- **> Next Page**: [Layer 3](/model/05.3-Layer-3)
 
 ---

--- a/docs/model/05.3-Layer-3.md
+++ b/docs/model/05.3-Layer-3.md
@@ -28,7 +28,7 @@ If created during planning, a policy document can serve as a functional design r
 
 ## Continue Reading
 
-- **< Previous Page**: [Layer 2](./05.2-Layer-2.html)
-- **> Next Page**: [Layer 4: Sensitive Activities](./06-sensitive-activities.html)
+- **< Previous Page**: [Layer 2](/model/05.2-Layer-2)
+- **> Next Page**: [Layer 4: Sensitive Activities](/model/06-sensitive-activities)
 
 ---

--- a/docs/model/06-sensitive-activities.md
+++ b/docs/model/06-sensitive-activities.md
@@ -29,7 +29,7 @@ We see a fuller example in **Figure 6.2**, continuing the process into evaluatio
 
 ## Continue Reading
 
-- **< Previous Page**: [Layer 3](./05.3-Layer-3.html)
-- **> Next Page**: [The Measurement Layers](./07-measurement-layers.html)
+- **< Previous Page**: [Layer 3](/model/05.3-Layer-3)
+- **> Next Page**: [The Measurement Layers](/model/07-measurement-layers)
 
 ---

--- a/docs/model/07-measurement-layers.md
+++ b/docs/model/07-measurement-layers.md
@@ -17,7 +17,7 @@ An old leadership adage states that “a unit only does well that which its comm
 
 ## Continue Reading
 
-- **< Previous Page**: [Layer 4: Sensitive Activities](./06-sensitive-activities.html)
-- **> Next Page**: [Layer 5](./07.1-Layer-5.html)
+- **< Previous Page**: [Layer 4: Sensitive Activities](/model/06-sensitive-activities)
+- **> Next Page**: [Layer 5](/model/07.1-Layer-5)
 
 ---

--- a/docs/model/07.1-Layer-5.md
+++ b/docs/model/07.1-Layer-5.md
@@ -28,7 +28,7 @@ As seen in **Figure 7.2**, proper maintenance of relationships, also known as â€
 
 ## Continue Reading
 
-- **< Previous Page**: [The Measurement Layers](./07-measurement-layers.html)
-- **> Next Page**: [Layer 6](./07.2-Layer-6.html)
+- **< Previous Page**: [The Measurement Layers](/model/07-measurement-layers)
+- **> Next Page**: [Layer 6](/model/07.2-Layer-6)
 
 ---

--- a/docs/model/07.2-Layer-6.md
+++ b/docs/model/07.2-Layer-6.md
@@ -17,5 +17,5 @@ Due to the volatile nature of many remediation activities, and the potential for
 
 Extending the point made in Figure 7.1, enforcement activities may find heightened success when properly mapped to evaluation results. This allows every person or system involved in the change to understand the complete justification, instead of the enforcement being applied arbitrarily.
 
-- **< Previous Page**: [Layer 5](./07.1-Layer-5.html)
-- **> Next Page**: [Layer 7](./07.3-Layer-7.html)
+- **< Previous Page**: [Layer 5](/model/07.1-Layer-5)
+- **> Next Page**: [Layer 7](/model/07.3-Layer-7)

--- a/docs/model/07.3-Layer-7.md
+++ b/docs/model/07.3-Layer-7.md
@@ -15,5 +15,5 @@ Audits are typically conducted in batches, and look for point-in-time evidence c
 
 Mature CCM operations establish a constant, ongoing, policy-driven process that harnesses multiple systems to ensure maximum visibility of all deployed assets at all times. A physical equivalent might be constant security patrols, live video surveillance, and active perimeter guards.
 
-- **< Previous Page**: [Layer 6](./07.2-Layer-6.html)
-- **> Next Page**: [The Need for Machine-Optimized Documentation Standards](./08-applying.html)
+- **< Previous Page**: [Layer 6](/model/07.2-Layer-6)
+- **> Next Page**: [The Need for Machine-Optimized Documentation Standards](/model/08-applying)

--- a/docs/model/08-applying.md
+++ b/docs/model/08-applying.md
@@ -5,7 +5,7 @@ title: The Need for Machine-Optimized Documentation Standards
 
 ## Going Beyond Machine-Readable
 
-As mentioned in the _[Prior Work](./03-foundational-concepts.md)_, the *GRC Engineering Model for Automated Risk Assessments* is the product of many previous iterations and learnings. 
+As mentioned in the _[Prior Work](./03-foundational-concepts)_, the *GRC Engineering Model for Automated Risk Assessments* is the product of many previous iterations and learnings. 
 
 Immense value has come from the work on OSCAL, where a large body of machine-readable documents have been crafted both publicly and privately by highly regulated organizations. The work done in the OSCAL space cannot be overlooked or discounted, as it has provided a great benefit to countless firms.
 
@@ -29,5 +29,5 @@ When a properly designed MCP system sits on top of a machine-optimized GRC datab
 
 When partnered with an Agent2Agent (A2A) enabled system — allowing GRC-specialized systems to provide precisely contextualized information to engineering-specialized systems in a near-deterministic manner — our AI systems will require dramatically fewer resources, our security tools increase in accuracy, less time is spent on false positives or negatives, and more time is spent delivering real value to the organization.
 
-- **< Previous Page**: [Layer 7](./07.3-Layer-7.html)
+- **< Previous Page**: [Layer 7](/model/07.3-Layer-7)
 <!-- - **> Next Page**: [Gemara SDKs](TODO)-->

--- a/docs/model/08-applying.md
+++ b/docs/model/08-applying.md
@@ -5,7 +5,7 @@ title: The Need for Machine-Optimized Documentation Standards
 
 ## Going Beyond Machine-Readable
 
-As mentioned in the _[Prior Work](./03-foundational-concepts)_, the *GRC Engineering Model for Automated Risk Assessments* is the product of many previous iterations and learnings. 
+As mentioned in the _[Prior Work](/model/03-foundational-concepts)_, the *GRC Engineering Model for Automated Risk Assessments* is the product of many previous iterations and learnings. 
 
 Immense value has come from the work on OSCAL, where a large body of machine-readable documents have been crafted both publicly and privately by highly regulated organizations. The work done in the OSCAL space cannot be overlooked or discounted, as it has provided a great benefit to countless firms.
 


### PR DESCRIPTION
## Description

This PR removes the html extensions from cross-site links and adds html proofer to check for links errors before merge.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [X] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [ ] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [X] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->
