### PR TITLE
fix: Sidebar to support index.md instead of custom file organization

### DIFF
--- a/.github/workflows/jekyll-site.yml
+++ b/.github/workflows/jekyll-site.yml
@@ -60,7 +60,7 @@ jobs:
           test -f docs/_site/lexicon/lexicon.html || { echo "Error: Missing lexicon.html"; exit 1; }
           # Verify sidebar is included in pages that should have it (not homepage)
           grep -q "Quick Links" docs/_site/lexicon/lexicon.html || { echo "Error: Sidebar not found in lexicon.html"; exit 1; }
-          grep -q "Quick Links" docs/_site/adr.html || { echo "Error: Sidebar not found in adr.html"; exit 1; }
+          grep -q "Quick Links" docs/_site/adrs/index.html || { echo "Error: Sidebar not found in adrs/index.html"; exit 1; }
           echo "Success: All expected pages generated successfully"
 
       - name: Upload artifact for GitHub Pages

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -1,11 +1,11 @@
 - title: Home
   url: /
 - title: The Model
-  url: /model.html
+  url: /model/index.html
 - title: Roadmap
   url: /roadmap.html
 - title: ADRs
-  url: /adr.html
+  url: /adrs/index.html
 - title: Community
   url: /community/index.html
   

--- a/docs/_includes/sidebar.html
+++ b/docs/_includes/sidebar.html
@@ -3,25 +3,52 @@
     <h3 class="sidebar-title">Quick Links</h3>
     <nav class="sidebar-nav">
       {%- for item in site.data.navigation -%}
-        {%- assign nav_page = site.pages | where: "url", item.url | first -%}
-        {%- if nav_page.nav-title and nav_page.nav-title != "" -%}
-          {%- assign dir_name = nav_page.nav-title | downcase -%}
-          {%- assign dir_path = dir_name | append: "/" -%}
-          {%- assign index_file = dir_name | append: ".md" -%}
-          {%- assign index_file_html = dir_name | append: ".html" -%}
-          <details class="sidebar-details">
-            <summary class="sidebar-summary">
-              <a href="{{ item.url | relative_url }}" class="sidebar-summary-link" onclick="event.stopPropagation();">{{ item.title | escape }}</a>
-            </summary>
-            <div class="sidebar-nested">
-              {%- assign child_pages = site.pages | sort: "path" -%}
-              {%- for child_page in child_pages -%}
-                {%- if child_page.path contains dir_path and child_page.path contains ".md" and child_page.path != index_file and child_page.path != index_file_html -%}
-                  <a href="{{ child_page.url | relative_url }}" class="sidebar-link sidebar-nested-link">{{ child_page.title | default: child_page.name | escape }}</a>
+        {%- assign is_index_page = false -%}
+        {%- assign dir_name = "" -%}
+        {%- if item.url != "/" -%}
+          {%- if item.url contains "/index.html" -%}
+            {%- assign url_parts = item.url | split: "/" -%}
+            {%- assign dir_name = "" -%}
+            {%- for part in url_parts -%}
+              {%- if part != "" and part != "index.html" -%}
+                {%- if dir_name == "" -%}
+                  {%- assign dir_name = part -%}
+                {%- else -%}
+                  {%- assign dir_name = dir_name | append: "/" | append: part -%}
                 {%- endif -%}
-              {%- endfor -%}
-            </div>
-          </details>
+              {%- endif -%}
+            {%- endfor -%}
+            {%- if dir_name != "" -%}
+              {%- assign is_index_page = true -%}
+            {%- endif -%}
+          {%- endif -%}
+        {%- endif -%}
+        {%- if is_index_page -%}
+          {%- assign dir_path = dir_name | append: "/" -%}
+          {%- assign index_file = dir_name | append: "/index.md" -%}
+          {%- assign has_children = false -%}
+          {%- assign child_pages = site.pages | sort: "path" -%}
+          {%- for child_page in child_pages -%}
+            {%- if child_page.path contains dir_path and child_page.path contains ".md" and child_page.path != index_file -%}
+              {%- assign has_children = true -%}
+            {%- endif -%}
+          {%- endfor -%}
+          {%- if has_children -%}
+            <details class="sidebar-details">
+              <summary class="sidebar-summary">
+                <a href="{{ item.url | relative_url }}" class="sidebar-summary-link" onclick="event.stopPropagation();">{{ item.title | escape }}</a>
+              </summary>
+              <div class="sidebar-nested">
+                {%- for child_page in child_pages -%}
+                  {%- if child_page.path contains dir_path and child_page.path contains ".md" and child_page.path != index_file -%}
+                    <a href="{{ child_page.url | relative_url }}" class="sidebar-link sidebar-nested-link">{{ child_page.title | default: child_page.name | escape }}</a>
+                  {%- endif -%}
+                {%- endfor -%}
+              </div>
+            </details>
+          {%- else -%}
+            <a href="{{ item.url | relative_url }}" class="sidebar-link">{{ item.title | escape }}</a>
+          {%- endif -%}
         {%- else -%}
           <a href="{{ item.url | relative_url }}" class="sidebar-link">{{ item.title | escape }}</a>
         {%- endif -%}

--- a/docs/adrs/index.md
+++ b/docs/adrs/index.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-nav-title: ADRs
 ---
 
 # Architecture Decision Records

--- a/docs/implementation/index.md
+++ b/docs/implementation/index.md
@@ -93,13 +93,13 @@ The Implementation evolves based on community needs:
 - **Schema improvements?** Open an issue or submit a PR
 - **New features or APIs?** Propose changes via PR
 - **Found a bug?** Report it
-- **Significant architectural changes?** Document in an [ADR](../adr.html)
+- **Significant architectural changes?** Document in an [ADR](../adrs/index.html)
 
 See the [Contributing Guide](https://github.com/gemaraproj/gemara/blob/main/CONTRIBUTING.md) for details.
 
 ## Architecture Decisions
 
-Significant implementation changes are documented in [Architecture Decision Records (ADRs)](../adr.html).
+Significant implementation changes are documented in [Architecture Decision Records (ADRs)](../adrs/index.html).
 
 ## Versioning and Maintenance
 

--- a/docs/model/01-scope.md
+++ b/docs/model/01-scope.md
@@ -9,7 +9,7 @@ The purpose of this model is to provide a common basis for approaching activitie
 
 ## Continue Reading
 
-- **< Previous Page**: [Introduction to the Model](../model.html)
+- **< Previous Page**: [Introduction to the Model](../index.html)
 - **> Next Page**: [Definitions](./02-definitions.html)
 
 ---

--- a/docs/model/index.md
+++ b/docs/model/index.md
@@ -1,6 +1,5 @@
 ---
 layout: page
-nav-title: Model
 ---
 
 # The Gemara Model
@@ -81,6 +80,6 @@ This model is intentionally stable. Changes are rare and require significant com
 
 ## Continue Reading
 
-- **> Next Page**: [Scope](./model/01-scope.html)
+- **> Next Page**: [Scope](./01-scope.html)
 
 ---


### PR DESCRIPTION
## Description

The sidebar previously did not support index files, and instead relied on a custom header field and specific file organization to identify files that act as parents. With some opaque shenanigans in the sidebar.html file, we can now build the sidebar dropdowns while organizing the files the way jekyll intended.

<!-- Provide a clear and concise description of what this PR does -->

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [x] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [ ] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->
