### PR TITLE
chore: update CUE package name to gemara and updates documentation

### DIFF
--- a/base.cue
+++ b/base.cue
@@ -1,6 +1,6 @@
 // Schema lifecycle: experimental | stable | deprecated
 @status("stable")
-package schemas
+package gemara
 
 import "time"
 

--- a/docs/schema/index.md
+++ b/docs/schema/index.md
@@ -64,25 +64,7 @@ Schema documentation generated from CUE. One page per schema file:
 
 ```bash
 go install cuelang.org/go/cmd/cue@latest
-
-# Initialize a CUE module in your project
-cue mod init
-```
-
-**Import the Gemara Module**
-```cue
-#myapp.cue
-package myapp
-
-import gemara "github.com/gemaraproj/gemara:schemas"
-
-gemara.#ControlCatalog
-```
-
-**Validate with the cue CLI**
-
-```bash
-cue vet your-controls.yaml myapp.cue 
+cue vet -c -d '#ControlCatalog' github.com/gemaraproj/gemara@latest your-controls.yaml
 ```
 
 ## Contributing

--- a/layer-1.cue
+++ b/layer-1.cue
@@ -1,7 +1,7 @@
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
 @if(!stable)
-package schemas
+package gemara
 
 @go(gemara)
 

--- a/layer-2.cue
+++ b/layer-2.cue
@@ -1,7 +1,7 @@
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
 @if(!stable)
-package schemas
+package gemara
 
 @go(gemara)
 

--- a/layer-3.cue
+++ b/layer-3.cue
@@ -1,7 +1,7 @@
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
 @if(!stable)
-package schemas
+package gemara
 
 @go(gemara)
 

--- a/layer-5.cue
+++ b/layer-5.cue
@@ -1,7 +1,7 @@
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
 @if(!stable)
-package schemas
+package gemara
 
 @go(gemara)
 

--- a/mapping.cue
+++ b/mapping.cue
@@ -1,7 +1,7 @@
 // Schema lifecycle: experimental | stable | deprecated
 @status("stable")
 
-package schemas
+package gemara
 
 // MappingReference represents a reference to an external document with full metadata.
 #MappingReference: {

--- a/metadata.cue
+++ b/metadata.cue
@@ -1,6 +1,6 @@
 // Schema lifecycle: experimental | stable | deprecated
 @status("stable")
-package schemas
+package gemara
 
 // Metadata represents common metadata fields shared across all layers
 #Metadata: {


### PR DESCRIPTION
## Description

Rename CUE package to `gemara` so we can drop `:schemas` from the import. Update the CUE validation docs to use a one-liner approach instead of CUE module creation.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [X] Layer 1 schema (`layer-1.cue`) changes
- [X] Layer 2 schema (`layer-2.cue`) changes
- [X] Layer 3 schema (`layer-3.cue`) changes
- [X] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

Package name only

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [X] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->
