### PR TITLE
feat!: updates family and category to use a single generic type Group

### DIFF
--- a/base.cue
+++ b/base.cue
@@ -57,26 +57,14 @@ import "time"
 // Date represents a date string (ISO 8601 date format)
 #Date: time.Format("2006-01-02") @go(Date,format="date")
 
-// Category represents a category used for applicability or classification
-#Category: {
+// Group represents a classification or grouping that can be used in different contexts with semantic meaning derived from its usage
+#Group: {
 	// id allows this entry to be referenced by other elements
 	id: string
 
-	// title describes the purpose of this category at a glance
+	// title describes the purpose of this group at a glance
 	title: string
 
-	// description explains the significance and traits of entries to this category
-	description: string
-}
-
-// Family represents a logical grouping of guidelines or controls which share a common purpose or function
-#Family: {
-	// id allows this entry to be referenced by other elements
-	id: string
-
-	// title describes the purpose of this family at a glance
-	title: string
-
-	// description explains the significance and traits of entries to this entity family
+	// description explains the significance and traits of entries to this group
 	description: string
 }

--- a/docs/schema-nav.yml
+++ b/docs/schema-nav.yml
@@ -8,8 +8,7 @@ pages:
       - "Email"
       - "Datetime"
       - "Date"
-      - "Category"
-      - "Family"
+      - "Group"
   - title: "Metadata"
     filename: "metadata"
     schemas:

--- a/layer-1.cue
+++ b/layer-1.cue
@@ -20,7 +20,7 @@ package gemara
 	"front-matter"?: string @go(FrontMatter) @yaml("front-matter,omitempty")
 
 	// families contains a list of guidance families that can be referenced by guidance
-	families?: [...#Family] @go(Families)
+	families?: [...#Group] @go(Families)
 
 	// guidelines is a list of unique guidelines defined by this catalog
 	guidelines?: [...#Guideline] @go(Guidelines)

--- a/layer-2.cue
+++ b/layer-2.cue
@@ -14,7 +14,7 @@ package gemara
 	"metadata": #Metadata @go(Metadata)
 
 	// families contains a list of control families that can be referenced by controls
-	families?: [...#Family] @go(Families)
+	families?: [...#Group] @go(Families)
 
 	// controls is a list of unique controls defined by this catalog
 	controls?: [...#Control] @go(Controls)

--- a/metadata.cue
+++ b/metadata.cue
@@ -23,7 +23,7 @@ package gemara
 	"mapping-references"?: [...#MappingReference] @go(MappingReferences) @yaml("mapping-references,omitempty")
 
 	// applicability-categories is a list of categories used to classify within this artifact to specify scope
-	"applicability-categories"?: [...#Category] @go(ApplicabilityCategories) @yaml("applicability-categories,omitempty")
+	"applicability-categories"?: [...#Group] @go(ApplicabilityCategories) @yaml("applicability-categories,omitempty")
 
 	// draft indicates whether this artifact is a pre-release version; open to modification
 	draft?: bool


### PR DESCRIPTION
## Description

This PR merges Family and Categories into type Group. Group is a  neutral term that can be used in the context of control families and applicability categories. 

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [X] Layer 1 schema (`layer-1.cue`) changes
- [X] Layer 2 schema (`layer-2.cue`) changes
- [] Layer 3 schema (`layer-3.cue`) changes
- [] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

Structure of `Category` and `Family` are retained and changes to neutral term of `Group`.

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

Closes #291 

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [ ] This PR has content that was created with AI assistance. 
   - [ ]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [ ] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.


---