### PR TITLE
feat: change metadata.date from #Date to #Datetime

### DIFF
--- a/base.cue
+++ b/base.cue
@@ -54,9 +54,6 @@ import "time"
 // Datetime represents an ISO 8601 formatted datetime string
 #Datetime: time.Format("2006-01-02T15:04:05Z07:00") @go(Datetime,format="date-time")
 
-// Date represents a date string (ISO 8601 date format)
-#Date: time.Format("2006-01-02") @go(Date,format="date")
-
 // Group represents a classification or grouping that can be used in different contexts with semantic meaning derived from its usage
 #Group: {
 	// id allows this entry to be referenced by other elements

--- a/docs/schema-nav.yml
+++ b/docs/schema-nav.yml
@@ -7,7 +7,6 @@ pages:
       - "ActorType"
       - "Email"
       - "Datetime"
-      - "Date"
       - "Group"
   - title: "Metadata"
     filename: "metadata"

--- a/metadata.cue
+++ b/metadata.cue
@@ -11,7 +11,7 @@ package gemara
 	version?: string
 
 	// date is the publication or effective date of this artifact
-	date?: #Date @go(Date)
+	date?: #Datetime @go(Date)
 
 	// description provides a high-level summary of the artifact's purpose and scope
 	description: string


### PR DESCRIPTION
## Description

Date is fine for layers 1 through 3. But in layer 5 (evaluation logs), we are very likely to have multiple entries per day. So we need to change #Date to #Datetime in the metadata.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [x] Layer 1 schema (`layer-1.cue`) changes
- [x] Layer 2 schema (`layer-2.cue`) changes
- [x] Layer 3 schema (`layer-3.cue`) changes
- [x] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [ ] This PR has content that was created with AI assistance. 
   - [ ]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [ ] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.


---