### PR TITLE
docs: adds status from CUE attributes to generated schema docs

### DIFF
--- a/.github/workflows/jekyll-site.yml
+++ b/.github/workflows/jekyll-site.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.23'
+          go-version: '1.24'
 
       - name: Generate documentation
         run: make gendocs

--- a/cmd/go.mod
+++ b/cmd/go.mod
@@ -1,8 +1,6 @@
 module github.com/gemaraproj/gemara
 
-go 1.24.0
-
-toolchain go1.24.12
+go 1.24.13
 
 require (
 	cuelang.org/go v0.15.4

--- a/docs/adrs/0010-dual-ladder-layers.md
+++ b/docs/adrs/0010-dual-ladder-layers.md
@@ -19,7 +19,7 @@ Here is an overview of some common phrasing we've been using:
 - Layer 4: Sensitive Activities
 - Layer 5: Evaluation (config scans and behavior scans)
 - Layer 6: Enforcement (gates and remediation)
-- Layer 7: Audit (manual and continuous monitoring
+- Layer 7: Audit (manual and continuous monitoring)
 
 ## Decision
 

--- a/docs/adrs/0010-dual-ladder-layers.md
+++ b/docs/adrs/0010-dual-ladder-layers.md
@@ -19,7 +19,7 @@ Here is an overview of some common phrasing we've been using:
 - Layer 4: Sensitive Activities
 - Layer 5: Evaluation (config scans and behavior scans)
 - Layer 6: Enforcement (gates and remediation)
-- Layer 7: Audit (manual and continuous monitoring)
+- Layer 7: Audit (manual and continuous monitoring
 
 ## Decision
 

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1104,6 +1104,30 @@ a[href^="http"]:not([href*="gemara"]):not([href*="openssf"]):not(.social-media-l
   border: 1px solid rgba(139, 92, 246, 0.4);
 }
 
+.badge-experimental {
+  background: rgba(243, 156, 18, 0.15);
+  color: #b45309;
+  border: 1px solid rgba(243, 156, 18, 0.3);
+}
+
+[data-theme="dark"] .badge-experimental {
+  background: rgba(251, 191, 36, 0.2);
+  color: #fbbf24;
+  border: 1px solid rgba(251, 191, 36, 0.4);
+}
+
+.badge-deprecated {
+  background: rgba(231, 76, 60, 0.15);
+  color: #c0392b;
+  border: 1px solid rgba(231, 76, 60, 0.3);
+}
+
+[data-theme="dark"] .badge-deprecated {
+  background: rgba(239, 68, 68, 0.2);
+  color: #ef4444;
+  border: 1px solid rgba(239, 68, 68, 0.4);
+}
+
 /* ============================================
    Component Content Styling
    ============================================ */

--- a/layer-1.cue
+++ b/layer-1.cue
@@ -1,6 +1,5 @@
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
-@if(!stable)
 package gemara
 
 @go(gemara)

--- a/layer-2.cue
+++ b/layer-2.cue
@@ -1,6 +1,5 @@
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
-@if(!stable)
 package gemara
 
 @go(gemara)

--- a/layer-3.cue
+++ b/layer-3.cue
@@ -1,6 +1,5 @@
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
-@if(!stable)
 package gemara
 
 @go(gemara)

--- a/layer-5.cue
+++ b/layer-5.cue
@@ -1,6 +1,5 @@
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
-@if(!stable)
 package gemara
 
 @go(gemara)


### PR DESCRIPTION
## Description

This PR adds the schema lifecycle status from CUE attributes to generated schema docs

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [X] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [ ] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [X] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

Blocked by #297 

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [X] This PR has content that was created with AI assistance. 
   - [X]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [X] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.


---