### PR TITLE
feat: adds states to guidelines, controls, and assessment requirements

### DIFF
--- a/base.cue
+++ b/base.cue
@@ -65,3 +65,6 @@ import "time"
 	// description explains the significance and traits of entries to this group
 	description: string
 }
+
+// Lifecycle represents the lifecycle state of a guideline, control, or assessment requirement
+#Lifecycle: *"active" | "draft" | "deprecated" | "retired" @go(-)

--- a/layer-1.cue
+++ b/layer-1.cue
@@ -95,6 +95,17 @@ package gemara
 
 	// see-also lists related guideline IDs within the same GuidanceCatalog
 	"see-also"?: [...string] @go(SeeAlso) @yaml("see-also,omitempty")
+
+	// state is the lifecycle state of this guideline
+	state: #Lifecycle @go(State) @yaml("state,omitempty")
+
+	// replaced-by references the guideline that supersedes this one when deprecated or retired
+	"replaced-by"?: #EntryMapping @go(ReplacedBy,optional=nillable) @yaml("replaced-by,omitempty")
+
+	// retired guidelines must not have recommendations
+	if state == "retired" {
+		recommendations?: _|_
+	}
 }
 
 // Statement represents a structural sub-requirement within a guideline;

--- a/layer-2.cue
+++ b/layer-2.cue
@@ -45,6 +45,12 @@ package gemara
 
 	// threat-mappings documents relationships betwen this control and Layer 2 threat artifacts
 	"threat-mappings"?: [...#MultiEntryMapping] @go(ThreatMappings)
+
+	// state is the lifecycle state of this control
+	state: #Lifecycle @go(State) @yaml("state,omitempty")
+
+	// replaced-by references the control that supersedes this one when deprecated or retired
+	"replaced-by"?: #EntryMapping @go(ReplacedBy,optional=nillable) @yaml("replaced-by,omitempty")
 }
 
 // AssessmentRequirement describes a tightly scoped, verifiable condition that must be satisfied and confirmed by an evaluator
@@ -60,6 +66,17 @@ package gemara
 
 	// recommendation provides readers with non-binding suggestions to aid in evaluation or enforcement of the requirement
 	recommendation?: string
+
+	// state is the lifecycle state of this assessment requirement
+	state: #Lifecycle @go(State) @yaml("state,omitempty")
+
+	// replaced-by references the assessment requirement that supersedes this one when deprecated or retired
+	"replaced-by"?: #EntryMapping @go(ReplacedBy,optional=nillable) @yaml("replaced-by,omitempty")
+
+	// retired assessment requirements must not have a recommendation
+	if state == "retired" {
+		recommendation?: _|_
+	}
 }
 
 // ThreatCatalog describes a set of topically-associated threats

--- a/test-data/bad-lifecycle.yaml
+++ b/test-data/bad-lifecycle.yaml
@@ -1,0 +1,23 @@
+metadata:
+  id: TEST-BAD-LIFECYCLE
+  description: Retired guideline with recommendations should fail validation.
+  author:
+    id: test
+    name: Test Author
+    type: Human
+
+title: Bad Lifecycle Test
+type: Standard
+families:
+  - id: fam-1
+    title: Family One
+    description: Test family.
+
+guidelines:
+  - id: GL-001
+    family: fam-1
+    title: Retired Guideline With Recommendations
+    objective: This should fail because retired guidelines cannot have recommendations.
+    state: retired
+    recommendations:
+      - This recommendation should not exist on a retired guideline.

--- a/test-data/good-lifecycle.yaml
+++ b/test-data/good-lifecycle.yaml
@@ -1,0 +1,45 @@
+metadata:
+  id: TEST-LIFECYCLE
+  description: Validates lifecycle states on controls and assessment requirements.
+  author:
+    id: test
+    name: Test Author
+    type: Human
+  applicability-categories:
+    - id: production
+      title: Production
+      description: Production environments.
+
+title: Lifecycle Test Catalog
+families:
+  - id: dp
+    title: Data Protection
+    description: Data protection controls.
+
+controls:
+  - id: TC-001
+    family: dp
+    title: Encrypt Data at Rest
+    objective: Ensure all stored data is encrypted.
+    assessment-requirements:
+      - id: TC-001.AR01
+        text: The system MUST encrypt all data at rest.
+        applicability:
+          - production
+        recommendation: Use AES-256 or equivalent.
+
+  - id: TC-002
+    family: dp
+    title: Encrypt Data at Rest Using DES
+    objective: Ensure all stored data is encrypted using DES.
+    state: retired
+    replaced-by:
+      entry-id: TC-001
+    assessment-requirements:
+      - id: TC-002.AR01
+        text: The system MUST encrypt all data at rest using DES.
+        applicability:
+          - production
+        state: retired
+        replaced-by:
+          entry-id: TC-001.AR01


### PR DESCRIPTION
## Description

This PR adds lifecycle states to guidelines, controls, and assessment requirements to allow user to:

- define beta requirements or those that are being piloted
- define requirements being phased out
- define "tombstones" or requirement that are retired


## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [X] Layer 1 schema (`layer-1.cue`) changes
- [X] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

Optional fields added
state and replaced by

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [X] Manual testing performed
- [X] Test data updated (if applicable)

## Related Issues

Closes #218 

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->

Test with:
`cue vet -d '#ControlCatalog' . test-data/good-lifecycle.yaml`

`cue vet -d '#GuidanceCatalog' . test-data/bad-lifecycle.yaml`


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [X] This PR has content that was created with AI assistance. **ONLY THE TESTDATA**
   - [X]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [X] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.


---