### PR TITLE
feat: allow Layer 2 catalogs to extend other catalogs without specifying ids

### DIFF
--- a/layer-2.cue
+++ b/layer-2.cue
@@ -12,8 +12,8 @@ package gemara
 	// metadata provides detailed data about this catalog
 	metadata: #Metadata @go(Metadata)
 
-	// extends references a control catalog that this catalog builds upon
-	extends?: #EntryMapping @go(Extends,optional=nillable)
+	// extends references control catalogs that this catalog builds upon
+	extends?: [...#ArtifactMapping] @go(Extends)
 
 	// families contains a list of control families that can be referenced by controls
 	families?: [...#Group] @go(Families)
@@ -93,8 +93,8 @@ package gemara
 	// metadata provides detailed data about this catalog
 	metadata: #Metadata @go(Metadata)
 
-	// extends references a threat catalog that this catalog builds upon
-	extends?: #EntryMapping @go(Extends,optional=nillable)
+	// extends references threat catalogs that this catalog builds upon
+	extends?: [...#ArtifactMapping] @go(Extends)
 
 	// threats is a list of threats defined by this catalog
 	threats?: [...#Threat] @go(Threats)

--- a/layer-2.cue
+++ b/layer-2.cue
@@ -12,6 +12,9 @@ package gemara
 	// metadata provides detailed data about this catalog
 	metadata: #Metadata @go(Metadata)
 
+	// extends references a control catalog that this catalog builds upon
+	extends?: #EntryMapping @go(Extends,optional=nillable)
+
 	// families contains a list of control families that can be referenced by controls
 	families?: [...#Group] @go(Families)
 

--- a/layer-2.cue
+++ b/layer-2.cue
@@ -93,6 +93,9 @@ package gemara
 	// metadata provides detailed data about this catalog
 	metadata: #Metadata @go(Metadata)
 
+	// extends references a threat catalog that this catalog builds upon
+	extends?: #EntryMapping @go(Extends,optional=nillable)
+
 	// threats is a list of threats defined by this catalog
 	threats?: [...#Threat] @go(Threats)
 

--- a/mapping.cue
+++ b/mapping.cue
@@ -28,7 +28,7 @@ package gemara
 	"reference-id": string @go(ReferenceId)
 
 	// remarks is prose regarding the mapped artifact or the mapping relationship
-	remarks: string
+	remarks?: string
 }
 
 // MultiEntryMapping represents a mapping to an external reference with one or more entries.


### PR DESCRIPTION
## Description

This PR adds extends to the Layer 2 Catalog schemas to allow extension of catalog without specifying granular ids.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [X] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

- `ThreatCatalogs` can extend multiple "parent" Catalogs
- `ControlCatalogs` can extend multiple "parent" Catalogs
- `ArtifactMapping` remarks are optional


## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->

Example content:
```
metadata:
  id: ACME-CC
  version: "1.0.0"
  description: |
    Organization-specific control catalog that extends the FINOS CCC
    base controls with additional internal requirements.
  author:
    id: acme-security
    name: ACME Security Team
    type: Human
  mapping-references:
   - id: CCC.Core
     title: Common Cloud Controls Core
     version: v2025.10
     url: https://github.com/finos/common-cloud-controls/releases/download/v2025.10/CCC.Core_v2025.10.yaml
     description: |
        Foundational repository of reusable security controls, capabilities,
        and threat models from FINOS Common Cloud Controls.
    - id: OSPS
      title: Open Source Project Security Baseline
      version: 2026.02.19
      url: https://baseline.openssf.org/versions/2026-02-19.html
      description: |
        Security criteria for open source projects organized by maturity
        level and category.
title: ACME Cloud Control Catalog

extends:
  - reference-id: FINOS-CCC
    remarks: Inherits all base cloud controls.
  - reference-id: OSPS-BASELINE
```


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [ ] This PR has content that was created with AI assistance. 
   - [ ]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [ ] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.


---