### PR TITLE
feat: require families when guidelines or controls are present

### DIFF
--- a/layer-1.cue
+++ b/layer-1.cue
@@ -28,6 +28,10 @@ package gemara
 	// exemptions provides information about situations where this guidance is not applicable
 	exemptions?: [...#Exemption] @go(Exemptions)
 
+	if guidelines != _|_ {
+		families: [_, ...#Group]
+	}
+
 	// guidelines that extend other guidelines must be in the same family as the extended guideline
 	_validateExtensions: {
 		for guideline in guidelines if guideline.extends != _|_ {

--- a/layer-2.cue
+++ b/layer-2.cue
@@ -21,6 +21,10 @@ package gemara
 
 	// imported-controls is a list of controls from another source which are included as part of this document
 	"imported-controls"?: [...#MultiEntryMapping] @go(ImportedControls)
+
+	if controls != _|_ {
+		families: [_, ...#Group]
+	}
 }
 
 // Control describes a safeguard or countermeasure with a clear objective and assessment requirements


### PR DESCRIPTION
## Description

This PR adds conditional constraint to GuidanceCatalog and ControlCatalog that enforces at least one family when entries exist.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [X] Layer 1 schema (`layer-1.cue`) changes
- [X] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [ ] This PR has content that was created with AI assistance. 
   - [ ]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [ ] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.


---