### PR TITLE
docs: remove duplicate schema description

### DIFF
--- a/cmd/internal/cmd/openapi2md.go
+++ b/cmd/internal/cmd/openapi2md.go
@@ -552,6 +552,9 @@ func generateRootSection(rootName string, schema Schema, spec OpenAPISpec, schem
 	var buf strings.Builder
 
 	buf.WriteString(fmt.Sprintf("## `%s`\n\n", rootName))
+	if status := getSchemaStatus(schema); status != "" {
+		buf.WriteString(formatStatusBadge(status) + "\n\n")
+	}
 	if schema.Description != "" {
 		buf.WriteString(schema.Description + "\n\n")
 	}
@@ -562,16 +565,6 @@ func generateRootSection(rootName string, schema Schema, spec OpenAPISpec, schem
 			propNames = append(propNames, propName)
 		}
 		sort.Strings(propNames)
-
-		// Add status badge if present
-		if status := getSchemaStatus(schema); status != "" {
-			buf.WriteString(fmt.Sprintf(" %s", formatStatusBadge(status)))
-		}
-		buf.WriteString("\n\n")
-
-		if schema.Description != "" {
-			buf.WriteString(schema.Description + "\n\n")
-		}
 
 		// Output all fields in order (required first, then optional)
 		// Sort by required status, then by name


### PR DESCRIPTION
## Description

Removes extra schema description from generated documentation

Before:
<img width="1164" height="362" alt="Screenshot From 2026-03-02 13-41-56" src="https://github.com/user-attachments/assets/28f78ba2-2415-4116-9ecd-28e1dc98f8f0" />

After:
<img width="1179" height="304" alt="Screenshot From 2026-03-02 13-41-11" src="https://github.com/user-attachments/assets/7ddc80eb-6ea1-406b-bf67-8696af0c2a12" />


## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [X] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [ ] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [X] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [ ] This PR has content that was created with AI assistance. 
   - [ ]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [ ] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.


---