### PR TITLE
feat: Add risk catalog to layer 3

### DIFF
--- a/base.cue
+++ b/base.cue
@@ -83,7 +83,7 @@ import "time"
 }
 
 // Owner defines the RACI roles responsible for managing an artifact such as a risk
-#Owner: {
+#RACI: {
 	// responsible identifies the entities responsible for executing work to manage or mitigate the artifact
 	responsible: [...#Contact]
 

--- a/base.cue
+++ b/base.cue
@@ -82,6 +82,21 @@ import "time"
 	description: string
 }
 
+// Owner defines the RACI roles responsible for managing an artifact such as a risk
+#Owner: {
+	// responsible identifies the entities responsible for executing work to manage or mitigate the artifact
+	responsible: [...#Contact]
+
+	// accountable identifies the entity ultimately accountable for the outcome
+	accountable: [...#Contact]
+
+	// consulted identifies entities whose input is required when assessing or responding to the artifact
+	consulted?: [...#Contact]
+
+	// informed identifies entities that should be notified about changes to the artifact status
+	informed?: [...#Contact]
+}
+
 // Lifecycle represents the lifecycle state of a guideline, control, or assessment requirement
 #Lifecycle: *"Active" | "Draft" | "Deprecated" | "Retired" @go(-)
 

--- a/docs/schema-nav.yml
+++ b/docs/schema-nav.yml
@@ -58,7 +58,6 @@ pages:
       - "RiskCategory"
       - "Risk"
       - "Policy"
-      - "Contacts"
       - "RACI"
       - "Scope"
       - "Dimensions"

--- a/docs/schema-nav.yml
+++ b/docs/schema-nav.yml
@@ -59,6 +59,7 @@ pages:
       - "Risk"
       - "Policy"
       - "Contacts"
+      - "RACI"
       - "Scope"
       - "Dimensions"
       - "Imports"

--- a/docs/schema-nav.yml
+++ b/docs/schema-nav.yml
@@ -54,6 +54,8 @@ pages:
   - title: "Layer 3"
     filename: "layer-3"
     schemas:
+      - "RiskCatalog"
+      - "Risk"
       - "Policy"
       - "Contacts"
       - "Scope"

--- a/docs/schema-nav.yml
+++ b/docs/schema-nav.yml
@@ -55,6 +55,7 @@ pages:
     filename: "layer-3"
     schemas:
       - "RiskCatalog"
+      - "RiskCategory"
       - "Risk"
       - "Policy"
       - "Contacts"

--- a/layer-3.cue
+++ b/layer-3.cue
@@ -67,7 +67,7 @@ package gemara
 #Policy: {
 	title:                  string
 	metadata:               #Metadata
-	contacts:               #Contacts
+	contacts:               #RACI
 	scope:                  #Scope
 	imports:                #Imports
 	"implementation-plan"?: #ImplementationPlan @go(ImplementationPlan)
@@ -85,9 +85,6 @@ package gemara
 		metadata: "mapping-references": [_, ...]
 	}
 }
-
-// Contacts defines RACI roles for policy compliance and notification.
-#contacts?: #RACI @go(Contacts)
 
 // Scope defines what is included and excluded from policy applicability.
 #Scope: {

--- a/layer-3.cue
+++ b/layer-3.cue
@@ -51,7 +51,7 @@ package gemara
 	description: string
 
 	// severity describes the impact level
-	severity: "Low" | "Medium" | "High" | "Critical"
+	severity: #Severity @go(Severity)
 
 	// owner defines the RACI roles responsible for managing this risk
 	owner?: #Owner @go(Owner)

--- a/layer-3.cue
+++ b/layer-3.cue
@@ -15,9 +15,29 @@ package gemara
 	// metadata provides detailed data about this catalog
 	metadata: #Metadata @go(Metadata)
 
+	// categories is a list of risk categories used to classify risks
+	categories?: [...#RiskCategory] @go(Categories)
+
 	// risks is a list of risks defined by this catalog
 	risks?: [...#Risk] @go(Risks)
 }
+
+// RiskCategory describes a grouping of risks and defines appetite boundaries
+#RiskCategory: {
+	#Group
+
+	// appetite defines the acceptable level of risk for this category
+	appetite: #RiskAppetite @go(Appetite)
+
+	// max-severity defines the highest allowed severity within this category
+	"max-severity"?: #Severity @go(MaxSeverity) @yaml("max-severity,omitempty")
+}
+
+// Severity defines the allowed impact levels for a risk
+#Severity: "Low" | "Medium" | "High" | "Critical"
+
+// RiskAppetite defines the acceptable level of exposure for a risk category
+#RiskAppetite: "Zero" | "Low" | "Moderate" | "High"
 
 // A Risk represents the potential for negative impact resulting from one or more threats.
 #Risk: {
@@ -33,17 +53,14 @@ package gemara
 	// severity describes the impact level
 	severity: "Low" | "Medium" | "High" | "Critical"
 
-	// owner identifies the responsible party for managing the risk
-	owner?: string
+	// owner defines the RACI roles responsible for managing this risk
+	owner?: #Owner @go(Owner)
 
 	// impact describes the business or operational impact
 	impact?: string
 
-	// threat-mappings link this risk to Layer 2 threats
-	"threat-mappings"?: [...#MultiEntryMapping] @go(ThreatMappings)
-
-	// residual-risk describes risk remaining after controls are applied
-	"residual-risk"?: string
+	// threats link this risk to Layer 2 threats
+	"threats"?: [...#MultiEntryMapping] @go(Threats)
 }
 
 // Policy represents a policy document with metadata, contacts, scope, imports, implementation plan, risks, and adherence requirements.
@@ -124,16 +141,37 @@ package gemara
 // Risks defines mitigated and accepted risks addressed by this policy.
 #Risks: {
 	// Mitigated risks only need reference-id and risk-id (no justification required)
-	mitigated?: [...#MultiEntryMapping]
+	mitigated?: [...#MitigatedRisk]
 	// Accepted risks require rationale (justification) and may include scope. Controls addressing these risks are implicitly identified through threat mappings.
 	accepted?: [...#AcceptedRisk]
 }
 
-// RiskMapping maps a risk to a reference and optionally includes scope and justification.
-#AcceptedRisk: {
+// MitigatedRisk represents a risk addressed by the policy
+#MitigatedRisk: {
+	// id allows this mitigated risk entry to be referenced by accepted risks
+	id: string
+
+	// risk references the risk being mitigated
 	risk: #EntryMapping
-	// Scope and justification are only required for accepted risks (e.g., risk is accepted for TLP:Green and TLP:Clear because they contain non-sensitive data)
-	scope?:         #Scope
+}
+
+// AcceptedRisk documents a risk the organization has chosen to accept,
+// optionally linking it to a mitigated risk when the acceptance covers
+// residual risk after partial mitigation.
+#AcceptedRisk: {
+	// id allows this accepted risk entry to be referenced
+	id: string
+
+	// target-id optionally links this acceptance to a mitigated risk entry
+	"target-id"?: string
+
+	// risk references the risk being accepted
+	risk: #EntryMapping
+
+	// scope defines where the risk acceptance applies
+	scope?: #Scope
+
+	// justification explains why the risk is accepted
 	justification?: string
 }
 

--- a/layer-3.cue
+++ b/layer-3.cue
@@ -34,10 +34,10 @@ package gemara
 }
 
 // Severity defines the allowed impact levels for a risk
-#Severity: "Low" | "Medium" | "High" | "Critical"
+#Severity: "Low" | "Medium" | "High" | "Critical" @go(-)
 
 // RiskAppetite defines the acceptable level of exposure for a risk category
-#RiskAppetite: "Zero" | "Low" | "Moderate" | "High"
+#RiskAppetite: "Zero" | "Low" | "Moderate" | "High" @go(-)
 
 // A Risk represents the potential for negative impact resulting from one or more threats.
 #Risk: {
@@ -54,7 +54,7 @@ package gemara
 	severity: #Severity @go(Severity)
 
 	// owner defines the RACI roles responsible for managing this risk
-	owner?: #Owner @go(Owner)
+	owner?: #RACI @go(Owner)
 
 	// impact describes the business or operational impact
 	impact?: string
@@ -87,16 +87,7 @@ package gemara
 }
 
 // Contacts defines RACI roles for policy compliance and notification.
-#Contacts: {
-	// responsible is the person or group responsible for implementing controls for technical requirements
-	responsible: [...#Contact]
-	// accountable is the person or group accountable for evaluating and enforcing the efficacy of technical controls
-	accountable: [...#Contact]
-	// consulted is an optional person or group who may be consulted for more information about the technical requirements 
-	consulted?: [...#Contact]
-	// informed is an optional person or group who must receive updates about compliance with this policy 
-	informed?: [...#Contact]
-}
+#contacts?: #RACI @go(Contacts)
 
 // Scope defines what is included and excluded from policy applicability.
 #Scope: {

--- a/layer-3.cue
+++ b/layer-3.cue
@@ -40,13 +40,11 @@ package gemara
 	impact?: string
 
 	// threat-mappings link this risk to Layer 2 threats
-	"threat-mappings"?: [...#MultiEntryMapping]@go(ThreatMappings)
+	"threat-mappings"?: [...#MultiEntryMapping] @go(ThreatMappings)
 
 	// residual-risk describes risk remaining after controls are applied
 	"residual-risk"?: string
 }
-
-
 
 // Policy represents a policy document with metadata, contacts, scope, imports, implementation plan, risks, and adherence requirements.
 #Policy: {

--- a/layer-3.cue
+++ b/layer-3.cue
@@ -4,6 +4,50 @@ package gemara
 
 @go(gemara)
 
+// A RiskCatalog is a structured collection of documented risks that may affect an organization,
+// system, or service. It provides a centralized reference for risks that can be mapped to threats
+// and referenced by policies when documenting how those risks are mitigated or accepted.
+#RiskCatalog: {
+
+	// title describes the contents of this catalog at a glance
+	title: string
+
+	// metadata provides detailed data about this catalog
+	metadata: #Metadata @go(Metadata)
+
+	// risks is a list of risks defined by this catalog
+	risks?: [...#Risk] @go(Risks)
+}
+
+// A Risk represents the potential for negative impact resulting from one or more threats.
+#Risk: {
+	// id allows this risk to be referenced by other elements
+	id: string
+
+	// title describes the risk
+	title: string
+
+	// description explains the risk scenario
+	description: string
+
+	// severity describes the impact level
+	severity: "Low" | "Medium" | "High" | "Critical"
+
+	// owner identifies the responsible party for managing the risk
+	owner?: string
+
+	// impact describes the business or operational impact
+	impact?: string
+
+	// threat-mappings link this risk to Layer 2 threats
+	"threat-mappings"?: [...#MultiEntryMapping]@go(ThreatMappings)
+
+	// residual-risk describes risk remaining after controls are applied
+	"residual-risk"?: string
+}
+
+
+
 // Policy represents a policy document with metadata, contacts, scope, imports, implementation plan, risks, and adherence requirements.
 #Policy: {
 	title:                  string


### PR DESCRIPTION
## Description

This pr aims to add risk catalog to layer 3

## Schema Changes

The risk catalog and risk object are added to layer3.cue

### Schema Changes Made

- [ ] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [ ] Layer 2 schema (`layer-2.cue`) changes
- [x] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes


## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

fixes #292 

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [x] This PR has content that was created with AI assistance. **Improve comments** 
   - [x]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [x] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.


---