### PR TITLE
fix: go type annotations

### DIFF
--- a/base.cue
+++ b/base.cue
@@ -30,7 +30,7 @@ import "time"
 	name: string
 
 	// type specifies the type of entity interacting in the workflow
-	type: #EntityType @go(Type)
+	type: #EntityType
 
 	// version is the version of the entity (for tools; if applicable)
 	version?: string

--- a/layer-1.cue
+++ b/layer-1.cue
@@ -45,7 +45,7 @@ package gemara
 }
 
 // GuidanceType restricts the possible types that a catalog may be listed as
-#GuidanceType: "Standard" | "Regulation" | "Best Practice" | "Framework"
+#GuidanceType: "Standard" | "Regulation" | "Best Practice" | "Framework" @go(-)
 
 // Exemption describes a single scenario where the catalog is not applicable
 #Exemption: {

--- a/layer-3.cue
+++ b/layer-3.cue
@@ -109,7 +109,7 @@ package gemara
 	executor?:    #Actor
 }
 
-#MethodType: "Manual" | "Behavioral" | "Automated" | "Autoremediation" | "Gate"
+#MethodType: "Manual" | "Behavioral" | "Automated" | "Autoremediation" | "Gate" @go(-)
 
 // Parameter defines a configurable parameter for assessment or enforcement activities.
 #Parameter: {
@@ -160,4 +160,4 @@ package gemara
 }
 
 // ModType defines the type of modification to the assessment requirement.
-#ModType: "Add" | "Modify" | "Remove" | "Replace" | "Override"
+#ModType: "Add" | "Modify" | "Remove" | "Replace" | "Override" @go(-)

--- a/metadata.cue
+++ b/metadata.cue
@@ -10,7 +10,7 @@ package gemara
 	id: string
 
 	// type identifies the kind of Gemara artifact for unambiguous parsing
-	type: #ArtifactType @go(Type)
+	type: #ArtifactType
 
 	// gemara-version declares which version of the Gemara specification this artifact conforms to
 	"gemara-version": string @go(GemaraVersion) @yaml("gemara-version")


### PR DESCRIPTION
## Description

Some go types were being generated as strings where we intended them all to be manually entered as enums. 

Also I spotted two annotations that looked non-functional.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [x] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [ ] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes
