### PR TITLE
fix: make imports nillable in layer2

### DIFF
--- a/layer-2.cue
+++ b/layer-2.cue
@@ -22,7 +22,7 @@ package gemara
 	controls?: [...#Control] @go(Controls)
 
 	// imports contains controls from other sources which are included as part of this document
-	imports?: #ControlCatalogImports @go(Imports)
+	imports?: #ControlCatalogImports @go(Imports,optional=nillable)
 
 	// Constraints
 	if controls != _|_ {
@@ -110,7 +110,7 @@ package gemara
 	capabilities?: [...#Capability] @go(Capabilities)
 
 	// imports contains threats and capabilities from other sources which are included as part of this document
-	imports?: #ThreatCatalogImports @go(Imports)
+	imports?: #ThreatCatalogImports @go(Imports,optional=nillable)
 }
 
 // ThreatCatalogImports defines imported entries for a threat catalog


### PR DESCRIPTION
## Description

This PR makes Imports nillable in Layer 2 definitions. Results in a pointer in generated Go types so that unset imports are not written out as a field.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [X] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [ ] This PR has content that was created with AI assistance. 
   - [ ]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [ ] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.


---