### PR TITLE
fix: updates RiskCatalog to reference RiskCategory and add artifact type

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,21 @@ You have added a new schema 'newschema' in layerN.cue( where N is a number from 
 
 Use `cue fmt .` and `make cuefmtcheck` to ensure proper formatting and `make lintcue` to validate the syntax of your changes. If you forget to do this before opening a PR and your changes are invalid, the [CI workflow](.github/workflows/ci.yml) will fail and alert you.
 
+### Adding a new artifact type
+
+Adding a new artifact type requires schema changes, test data, and documentation updates. Follow the checklist below.
+
+| **Step** | **Action**                                                                                    |
+|:---------|:----------------------------------------------------------------------------------------------|
+| 1        | Define the new `#YourArtifact` definition in the appropriate `layer-N.cue` file               |
+| 2        | Add `"YourArtifact"` to the `#ArtifactType` enum in `base.cue`                                |
+| 3        | Add new enum or alias types to `docs/schema-nav.yml` under the correct layer                  |
+| 4        | Create a valid test data file in `test/test-data/` (prefix with `good-`)                      |
+| 5        | Add positive and/or negative test cases to `test/schema_test.go`                              |
+| 6        | Run `cue vet -d '#YourArtifact' . test/test-data/good-your-artifact.yaml` to validate locally |
+| 7        | Run `cue fmt .` and `make cuefmtcheck` to verify formatting                                   |
+| 8        | Run `make lintcue` and `make test` to confirm all checks pass                                 |
+
 ## Releases
 
 Releases are automatically created when a PR is merged into `main` with the `release` label. To trigger a release:

--- a/base.cue
+++ b/base.cue
@@ -101,7 +101,7 @@ import "time"
 #Lifecycle: *"Active" | "Draft" | "Deprecated" | "Retired" @go(-)
 
 // ArtifactType identifies the kind of Gemara artifact for unambiguous parsing
-#ArtifactType: "ControlCatalog" | "GuidanceCatalog" | "ThreatCatalog" | "Policy" | "MappingDocument" | "EvaluationLog" | "VectorCatalog" @go(-)
+#ArtifactType: "ControlCatalog" | "GuidanceCatalog" | "ThreatCatalog" | "RiskCatalog" | "Policy" | "MappingDocument" | "EvaluationLog" | "VectorCatalog" @go(-)
 
 // EntryType enumerates the atomic units within Gemara artifacts that can participate in mappings
 #EntryType: "Guideline" | "Statement" | "Control" | "AssessmentRequirement" | "Vector" @go(-)

--- a/docs/schema-nav.yml
+++ b/docs/schema-nav.yml
@@ -56,6 +56,8 @@ pages:
     schemas:
       - "RiskCatalog"
       - "RiskCategory"
+      - "Severity"
+      - "RiskAppetite"
       - "Risk"
       - "Policy"
       - "RACI"

--- a/layer-3.cue
+++ b/layer-3.cue
@@ -20,6 +20,11 @@ package gemara
 
 	// risks is a list of risks defined by this catalog
 	risks?: [...#Risk] @go(Risks)
+
+	// Constraints
+	if risks != _|_ {
+		categories: [_, ...#RiskCategory]
+	}
 }
 
 // RiskCategory describes a grouping of risks and defines appetite boundaries
@@ -49,6 +54,9 @@ package gemara
 
 	// description explains the risk scenario
 	description: string
+
+	// category references by id a catalog risk category that this risk belongs to
+	category: string @go(Category)
 
 	// severity describes the impact level
 	severity: #Severity @go(Severity)

--- a/test/schema_test.go
+++ b/test/schema_test.go
@@ -64,6 +64,9 @@ func TestSchemaValidation(t *testing.T) {
 		{"threats with vectors", "./test-data/good-threat-catalog.yaml", "#ThreatCatalog", false, ""},
 		{"vector mapping", "./test-data/good-vector-mitre-mapping.yaml", "#MappingDocument", false, ""},
 
+		// RiskCatalog — positive
+		{"valid risk catalog", "./test-data/good-risk-catalog.yaml", "#RiskCatalog", false, ""},
+
 		// Policy — positive
 		{"valid policy", "./test-data/good-policy.yaml", "#Policy", false, ""},
 		{"valid security policy", "./test-data/good-security-policy.yml", "#Policy", false, ""},

--- a/test/test-data/good-risk-catalog.yaml
+++ b/test/test-data/good-risk-catalog.yaml
@@ -1,0 +1,83 @@
+metadata:
+  id: EXAMPLE-RISK-CATALOG
+  type: RiskCatalog
+  gemara-version: "0.20.0"
+  version: "1.0.0"
+  description: Example Risk Catalog for cloud-native container environments
+  author:
+    id: risk-management-team
+    name: Risk Management Team
+    type: Human
+  mapping-references:
+    - id: EXAMPLE-THREAT-CATALOG
+      title: Example Threat Catalog
+      version: "1.0.0"
+      description: Container security threat catalog
+
+title: Cloud-Native Container Risk Catalog
+
+categories:
+  - id: CAT-OPERATIONAL
+    title: Operational Risk
+    description: Risks arising from failures in internal processes, systems, or external events that affect service availability and reliability
+    appetite: Moderate
+  - id: CAT-SECURITY
+    title: Security Risk
+    description: Risks arising from unauthorized access, data breaches, or exploitation of system vulnerabilities
+    appetite: Low
+    max-severity: High
+  - id: CAT-COMPLIANCE
+    title: Compliance Risk
+    description: Risks arising from failure to comply with applicable laws, regulations, or industry standards
+    appetite: Zero
+
+risks:
+  - id: RISK-001
+    title: Container Image Supply Chain Compromise
+    description: Third-party or base container images may contain known vulnerabilities or malicious code, leading to exploitation at runtime.
+    category: CAT-SECURITY
+    severity: High
+    owner:
+      responsible:
+        - name: Platform Engineering Lead
+          affiliation: Platform Team
+          email: platform-lead@example.org
+      accountable:
+        - name: Chief Information Security Officer
+          affiliation: Security
+          email: ciso@example.org
+    impact: Unauthorized code execution in production workloads, potential data exfiltration, and lateral movement across the cluster.
+    threats:
+      - reference-id: EXAMPLE-THREAT-CATALOG
+        entries:
+          - reference-id: THREAT-001
+
+  - id: RISK-002
+    title: Container Escape Leading to Host Compromise
+    description: Misconfigured or unpatched container runtimes may allow an attacker to escape container isolation and access the host.
+    category: CAT-SECURITY
+    severity: Critical
+    owner:
+      responsible:
+        - name: Platform Engineering Lead
+          affiliation: Platform Team
+          email: platform-lead@example.org
+      accountable:
+        - name: Chief Information Security Officer
+          affiliation: Security
+          email: ciso@example.org
+      consulted:
+        - name: Infrastructure Architect
+          affiliation: Architecture
+    impact: Full compromise of the underlying node, access to secrets, and disruption of co-located workloads.
+    threats:
+      - reference-id: EXAMPLE-THREAT-CATALOG
+        entries:
+          - reference-id: THREAT-002
+
+  - id: RISK-003
+    title: Regulatory Non-Compliance from Unaudited Deployments
+    description: Deploying workloads without automated compliance gates may result in violations of regulatory requirements.
+    category: CAT-COMPLIANCE
+    severity: Medium
+    impact: Regulatory fines, audit findings, and reputational damage.


### PR DESCRIPTION
## Description

This PR updates the RiskCatalog to ensure Risk has a reference to its RiskCategory `id` and add `RiskCatalog` as an artifact

- RiskCatalog test data added to validate
- `CONTRIBUTING.md` updates to include to assist with this type of task

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [ ] Layer 2 schema (`layer-2.cue`) changes
- [X] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [X] Unit tests added/updated
- [X] Manual testing performed
- [X] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [X] This PR has content that was created with AI assistance. **Test Data**
   - [X]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [X] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.


---