### PR TITLE
fix: replace Zero with Minimal in RiskAppetite enum

### DIFF
--- a/layer-3.cue
+++ b/layer-3.cue
@@ -34,15 +34,32 @@ package gemara
 	// appetite defines the acceptable level of risk for this category
 	appetite: #RiskAppetite @go(Appetite)
 
-	// max-severity defines the highest allowed severity within this category
+	// max-severity defines the risk tolerance boundary: the highest severity
+	// the organization will accept within this category
 	"max-severity"?: #Severity @go(MaxSeverity) @yaml("max-severity,omitempty")
 }
 
-// Severity defines the allowed impact levels for a risk
-#Severity: "Low" | "Medium" | "High" | "Critical" @go(-)
+// Severity defines the assessed level of a risk based on its potential impact and likelihood
+#Severity:
+	// minor consequence if realized; manageable within normal operations
+	"Low" |
+	// moderate consequence if realized; may impair specific functions or objectives
+	"Medium" |
+	// severe consequence if realized; likely to disrupt core operations or objectives
+	"High" |
+	// extreme consequence if realized; threatens organizational viability or mission
+	"Critical" @go(-)
 
 // RiskAppetite defines the acceptable level of exposure for a risk category
-#RiskAppetite: "Zero" | "Low" | "Moderate" | "High" @go(-)
+#RiskAppetite:
+	// organization is willing to accept higher cost to minimize risk
+	"Minimal" |
+	// organization favors caution but permits limited risk
+	"Low" |
+	// organization tolerates residual risk when justified by value
+	"Moderate" |
+	// organization is willing to operate with less restrictive controls
+	"High" @go(-)
 
 // A Risk represents the potential for negative impact resulting from one or more threats.
 #Risk: {
@@ -58,7 +75,7 @@ package gemara
 	// category references by id a catalog risk category that this risk belongs to
 	category: string @go(Category)
 
-	// severity describes the impact level
+	// severity describes the assessed level of this risk
 	severity: #Severity @go(Severity)
 
 	// owner defines the RACI roles responsible for managing this risk

--- a/test/test-data/good-risk-catalog.yaml
+++ b/test/test-data/good-risk-catalog.yaml
@@ -29,7 +29,7 @@ categories:
   - id: CAT-COMPLIANCE
     title: Compliance Risk
     description: Risks arising from failure to comply with applicable laws, regulations, or industry standards
-    appetite: Zero
+    appetite: Minimal
 
 risks:
   - id: RISK-001


### PR DESCRIPTION


## Description

The PR updates the Zero target to Minimal to reduce potential confusion. Though "Zero" is intended to be a target and not an outcome, it is unrealistic and "Minimal" is a more realistic term to use.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [ ] Layer 2 schema (`layer-2.cue`) changes
- [X] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

Replace `Zero` with `Minimal` is `RiskCategory`

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [X] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [X] This PR has content that was created with AI assistance. **Test data**
   - [X]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [X] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.


---