### PR TITLE
fix: adds missing colon to threat-assessment-guide

### DIFF
--- a/docs/tutorials/controls/threat-assessment-guide.md
+++ b/docs/tutorials/controls/threat-assessment-guide.md
@@ -113,7 +113,7 @@ It applies because mutable image tags let the tool resolve to a stale or comprom
 **Example (YAML)**
 
 ```yaml
-imports
+imports:
   threats:
   - reference-id: CCC
     entries:


### PR DESCRIPTION
## Description

<!-- Provide a clear and concise description of what this PR does -->
This PR adds a missing colon to the `imports:` for the Threat Assessment Guide. 

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [X] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [ ] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [X] Manual testing performed - `gitleaks dir tutorials`
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [ ] This PR has content that was created with AI assistance. 
   - [X]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [X] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.


---