### PR TITLE
fix: add strength to mapping document entries

### DIFF
--- a/mapping.cue
+++ b/mapping.cue
@@ -49,6 +49,9 @@ package gemara
 		}
 	}
 
+	// strength is the author's estimate of how completely the source entry satisfies the target entry; range 1-10
+	strength?: int & >=1 & <=10 @go(Strength)
+
 	"confidence-level"?: #ConfidenceLevel @go(ConfidenceLevel)
 
 	// applicability constrains the contexts in which this mapping holds

--- a/test/test-data/good-mapping-document.yaml
+++ b/test/test-data/good-mapping-document.yaml
@@ -70,6 +70,7 @@ mappings:
       entry-id: "2.1"
       entry-type: Guideline
     relationship: relates-to
+    strength: 6
     confidence-level: Medium
     applicability:
       - "manufacturer"
@@ -87,6 +88,7 @@ mappings:
       entry-id: "2.1"
       entry-type: Guideline
     relationship: implements
+    strength: 9
     confidence-level: High
     applicability:
       - "open-source-steward"


### PR DESCRIPTION
## Description

This PR adds back the `strength` field to the Mapping Document entries to denote functional overlap or relationship strength. 

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [ ] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [ ] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes
- [X] MappingDocument (`mapping.cue`) changes

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [X] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [ ] This PR has content that was created with AI assistance. 
   - [ ]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [ ] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.


---