### PR TITLE
fix: update control import statement to match latest schema

### DIFF
--- a/docs/tutorials/controls/control-catalog.yaml
+++ b/docs/tutorials/controls/control-catalog.yaml
@@ -55,11 +55,12 @@ families:
       Controls that ensure container images are authentic, unmodified,
       and from trusted sources throughout retrieval and use.
 
-imported-controls:
-  - reference-id: CCC
-    entries:
-      - reference-id: CCC.Core.CTL42
-        remarks: Image signing and verification
+imports:
+  controls:
+    - reference-id: CCC
+      entries:
+        - reference-id: CCC.Core.CTL42
+          remarks: Image signing and verification
 
 controls:
   - id: SEC.SLAM.CM.CTL01


### PR DESCRIPTION
## Description

The example `control-catalog.yaml` uses the legacy `imported-controls` field, which is rejected by the current CUE schema. The tutorial prose in the [Control Catalog Guide](https://gemara.openssf.org/tutorials/controls/control-catalog-guide) already documents the correct `imports.controls` structure.

This PR updates the example YAML to match.

## Changes

- `docs/tutorials/controls/control-catalog.yaml`: Replace `imported-controls` with `imports.controls`
## Schema Changes

n/a

### Schema Changes Made

- [X] No schema changes
- [ ] Layer 1 schema (`layer-1.cue`) changes
- [ ] Layer 2 schema (`layer-2.cue`) changes
- [ ] Layer 3 schema (`layer-3.cue`) changes
- [ ] Layer 5 schema (`layer-5.cue`) changes

### Schema Change Details

n/a

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [X] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->


## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [X] This PR has content that was created with AI assistance. 
- [X]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [X] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.

> Assisted with Cursor AI
---