### PR TITLE
docs: update with latest features

### DIFF
--- a/docs/schema/index.md
+++ b/docs/schema/index.md
@@ -4,7 +4,7 @@ title: Gemara Schemas
 nav-title: Schema
 ---
 
-Schemas (CUE format) standardize the expression of elements in the model and enable automated interoperability between [GRC](../model/02-definitions.html#grc) tools. These schemas provide validation across all layers.
+Schemas (CUE format) standardize the expression of elements in the model and enable automated interoperability between GRC tools. These schemas provide validation across all layers.
 
 Click on an artifact to view its schema:
 
@@ -96,6 +96,7 @@ Schema documentation generated from CUE. One page per schema file:
 - [Risk Catalog](riskcatalog.html)
 - [Policy](policy.html)
 - [Mapping Document](mappingdocument.html)
+- [Lexicon](lexicon.html)
 - [Evaluation Log](evaluationlog.html)
 - [Enforcement Log](enforcementlog.html)
 - [Audit Log](auditlog.html)

--- a/docs/sdk/go-sdk.md
+++ b/docs/sdk/go-sdk.md
@@ -3,7 +3,7 @@ layout: page
 title: Go SDK
 ---
 
-The Go SDK provides type-safe APIs for reading, writing, and manipulating Gemara documents. Types are generated from CUE schemas using [cuegen](https://github.com/gemaraproj/cuegen).
+The Go SDK provides type-safe APIs for reading, writing, converting, and bundling Gemara documents. Types are generated from CUE schemas using [cuegen](https://github.com/gemaraproj/cuegen).
 
 **[Go Package Reference →](https://pkg.go.dev/github.com/gemaraproj/go-gemara)**
 
@@ -13,22 +13,125 @@ The Go SDK provides type-safe APIs for reading, writing, and manipulating Gemara
 go get github.com/gemaraproj/go-gemara
 ```
 
-## Usage
+## Loading Documents
+
+`gemara.Load` is a generic loader — substitute the type parameter for any document kind (`gemara.GuidanceCatalog`, `gemara.ControlCatalog`, `gemara.Policy`, `gemara.EvaluationLog`, etc.). Format (YAML or JSON) is detected from the file extension.
 
 ```go
-import "github.com/gemaraproj/go-gemara"
+package main
 
-// Load a control catalog
-catalog := &gemara.Catalog{}
-catalog, err := catalog.LoadFile("file://controls.yaml")
-if err != nil {
-    log.Fatal(err)
-}
+import (
+    "context"
+    "fmt"
+    "log"
 
-// Access controls
-for _, control := range catalog.Controls {
-    fmt.Printf("Control: %s - %s\n", control.ID, control.Title)
+    "github.com/gemaraproj/go-gemara"
+    "github.com/gemaraproj/go-gemara/fetcher"
+)
+
+func main() {
+    f := &fetcher.File{}
+    ctx := context.Background()
+
+    catalog, err := gemara.Load[gemara.ControlCatalog](ctx, f, "path/to/controls.yaml")
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    for _, control := range catalog.Controls {
+        fmt.Printf("Control: %s - %s\n", control.Id, control.Title)
+    }
 }
+```
+
+The `fetcher` package provides three implementations of the `gemara.Fetcher` interface:
+
+- `fetcher.File` — reads from the local filesystem
+- `fetcher.HTTP` — fetches over HTTP(S)
+- `fetcher.URI` — dispatches by scheme (`file://`, `http(s)://`, or bare paths)
+
+`ControlCatalog` and `GuidanceCatalog` also expose `LoadFiles` for merging multiple sources, and `ControlCatalog.LoadNestedCatalog` for YAML files where the catalog is wrapped in a single key (e.g. `catalog:`).
+
+## Converting to OSCAL
+
+```go
+import (
+    "github.com/gemaraproj/go-gemara"
+    "github.com/gemaraproj/go-gemara/fetcher"
+    "github.com/gemaraproj/go-gemara/gemaraconv"
+)
+
+f := &fetcher.File{}
+ctx := context.Background()
+
+catalog, _ := gemara.Load[gemara.ControlCatalog](ctx, f, "path/to/catalog.yaml")
+oscalCatalog, _ := gemaraconv.ControlCatalog(catalog).ToOSCAL()
+
+guidance, _ := gemara.Load[gemara.GuidanceCatalog](ctx, f, "path/to/guidance.yaml")
+oscalCat, oscalProfile, _ := gemaraconv.GuidanceCatalog(guidance).ToOSCAL("relative/path/to/catalog.json")
+```
+
+A `ControlCatalog` can also be rendered to Markdown via `gemaraconv.ControlCatalog(catalog).ToMarkdown(ctx)`.
+
+## Converting to SARIF
+
+`EvaluationLog` results can be emitted as SARIF for surfacing in code-scanning tools. A `ControlCatalog` is required to resolve control metadata referenced from the log.
+
+```go
+catalog, _ := gemara.Load[gemara.ControlCatalog](ctx, f, "path/to/catalog.yaml")
+
+evaluationLog := &gemara.EvaluationLog{ /* populate */ }
+sarifBytes, _ := gemaraconv.EvaluationLog(evaluationLog).ToSARIF("path/to/artifact.md", catalog)
+```
+
+## Bundling and Distributing via OCI
+
+The `bundle` package assembles the full dependency tree (`extends` + `imports`) of a Gemara document, packs it into an OCI layout, and pushes it to a registry.
+
+```go
+import (
+    "github.com/gemaraproj/go-gemara/bundle"
+    "github.com/gemaraproj/go-gemara/fetcher"
+    "oras.land/oras-go/v2"
+    "oras.land/oras-go/v2/content/oci"
+    "oras.land/oras-go/v2/registry/remote"
+)
+
+data, _ := os.ReadFile("policy.yaml")
+src := bundle.File{Name: "policy.yaml", Data: data}
+
+m := bundle.Manifest{BundleVersion: "1", GemaraVersion: "v1.0.0"}
+asm := bundle.NewAssembler(&fetcher.URI{})
+b, _ := asm.Assemble(ctx, m, src)
+
+layoutStore, _ := oci.New("./bundle-output")
+desc, _ := bundle.Pack(ctx, layoutStore, b)
+_ = layoutStore.Tag(ctx, desc, "v1.0.0")
+
+repo, _ := remote.NewRepository("registry.example.com/org/bundle")
+tagDesc, _ := layoutStore.Resolve(ctx, "v1.0.0")
+_ = oras.CopyGraph(ctx, layoutStore, repo, tagDesc, oras.DefaultCopyGraphOptions)
+_ = repo.Tag(ctx, tagDesc, "v1.0.0")
+
+unpacked, _ := bundle.Unpack(ctx, repo, "v1.0.0")
+_ = unpacked
+```
+
+## CLI: `oscalexport`
+
+The repository also ships an `oscalexport` command that converts Gemara documents to OSCAL without writing any Go.
+
+```bash
+# Build
+make build
+
+# Convert a Control Catalog
+./bin/oscalexport catalog ./path/to/catalog.yaml --output ./catalog.json
+
+# Convert a Guidance Catalog (emits an OSCAL Catalog and Profile)
+./bin/oscalexport guidance ./path/to/guidance.yaml \
+    --catalog-output ./guidance.json \
+    --profile-output ./profile.json
 ```
 
 ## Relationship to Other Components
@@ -37,4 +140,4 @@ for _, control := range catalog.Controls {
 Provides the conceptual foundation. Go SDK types correspond to elements in the model.
 
 ### [The Schemas](../schema/)
-Go SDK types are generated from the CUE schemas, ensuring consistency between validation and programmatic access.
+Go SDK types are generated from the CUE schemas, ensuring consistency between validation and programmatic access. The schema version supported by a given SDK release is exposed as `gemara.SchemaVersion`.

--- a/docs/sdk/go-sdk.md
+++ b/docs/sdk/go-sdk.md
@@ -117,22 +117,9 @@ unpacked, _ := bundle.Unpack(ctx, repo, "v1.0.0")
 _ = unpacked
 ```
 
-## CLI: `oscalexport`
+## Developer Tooling
 
-The repository also ships an `oscalexport` command that converts Gemara documents to OSCAL without writing any Go.
-
-```bash
-# Build
-make build
-
-# Convert a Control Catalog
-./bin/oscalexport catalog ./path/to/catalog.yaml --output ./catalog.json
-
-# Convert a Guidance Catalog (emits an OSCAL Catalog and Profile)
-./bin/oscalexport guidance ./path/to/guidance.yaml \
-    --catalog-output ./guidance.json \
-    --profile-output ./profile.json
-```
+The SDK repository also includes two binaries — `oscalexport` and `typestagger` — that exist as test and development infrastructure for SDK maintainers, not as supported end-user CLIs. `oscalexport` is used to regenerate OSCAL fixtures from the bundled test catalogs (`make oscal-export`), and `typestagger` post-processes generated Go types after `make generate`. See the [`go-gemara` repository](https://github.com/gemaraproj/go-gemara) for usage in a development workflow.
 
 ## Relationship to Other Components
 


### PR DESCRIPTION
## Description

Update docs with latest changes to `go-gemara`

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [x] No schema changes
- [ ] Audit Log schema (`auditlog.cue`) changes
- [ ] Capability Catalog schema (`capabilitycatalog.cue`) changes
- [ ] Control Catalog schema (`controlcatalog.cue`) changes
- [ ] Enforcement Log schema (`enforcementlog.cue`) changes
- [ ] Evaluation Log schema (`evaluationlog.cue`) changes
- [ ] Guidance Catalog schema (`guidancecatalog.cue`) changes
- [ ] Mapping Document schema (`mappingdocument.cue`) changes
- [ ] Policy Document schema (`policy.cue`) changes
- [ ] Principle Catalog schema (`principlecatalog.cue`) changes
- [ ] Risk Catalog schema (`riskcatalog.cue`) changes
- [ ] Threat Catalog schema (`threatcatalog.cue`) changes
- [ ] Vector Catalog schema (`vectorcatalog.cue`) changes
- [ ] Other

### Schema Change Details

<!-- If schema changes were made, please describe:
- What fields/types were added, modified, or removed?
- What is the impact of these changes?
- Are these changes backward compatible?
- Do any generated types need to be regenerated?
-->

```
<!-- If applicable, provide a brief summary or example of schema changes -->
```

## Testing

<!-- Describe the tests you ran and how to reproduce them -->

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

<!-- Link to related issues using keywords (e.g., "Fixes #123", "Closes #456") -->

## Reviewer Hints

<!-- Help reviewers by highlighting:
- Areas that need special attention or focus
- Complex logic or design decisions that warrant discussion
- Known limitations or trade-offs
- Testing approach or edge cases to verify
- Files or functions that changed significantly
-->



 ---

## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [x] This PR has content that was created with AI assistance. 
   - [x]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [x] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.
