### PR TITLE
chore: bump ospo-reusable-workflows release.yaml to v1.0.1

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -8,6 +8,9 @@ template: |
   See details of [all code changes](https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION) since previous release
 
 categories:
+  - title: "💥 Breaking Changes"
+    labels:
+      - "breaking"
   - title: "🚀 Features"
     labels:
       - "feature"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,12 @@ on:
 jobs:
   release:
     permissions:
-      contents: write
-      pull-requests: read
+      contents: write       # Create release and push tags
+      pull-requests: read   # Read PR labels for release-drafter
+      packages: write       # Push container image to ghcr.io
+      id-token: write       # Federate for artifact attestation
+      attestations: write   # Generate build provenance attestations
+      discussions: write    # Create release announcement discussion
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,20 +2,16 @@
 name: "Release"
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches:
       - main
 jobs:
   release:
-    if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.merged == true &&
-      contains(github.event.pull_request.labels.*.name, 'release'))
     permissions:
       contents: write
       pull-requests: read
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@a0cf79bd8756e0a9c1555bf4975eae7ce7a8e8dc
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
     with:
       publish: true
       release-config-name: release-drafter.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
       id-token: write       # Federate for artifact attestation
       attestations: write   # Generate build provenance attestations
       discussions: write    # Create release announcement discussion
-    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@592067a69a43d2285f933753d89a7c9d51b96530 # v1.0.0
+    uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@e92cb6053ace495fe40a5f185988557afcdcecbc # v1.0.1
     with:
       publish: true
       release-config-name: release-drafter.yml


### PR DESCRIPTION
## What

Pin the reusable release workflow to v1.0.0 (SHA 592067a69a43d2285f933753d89a7c9d51b96530). Add a Breaking Changes category to release-drafter.

## Why

v1.0.0 of ospo-reusable-workflows broadens the release trigger to include breaking, feature, vuln, and release labels and folds GoReleaser, container image build, attestation, and discussion creation into the reusable workflow itself. Surfacing breaking changes prominently in release notes aligns the changelog with the new label-based release triggers.

## Notes

- The outer label-filter `if:` block on the release job is removed because the v1.0 reusable workflow now handles label filtering internally.
- Trigger updated to `pull_request_target` so the workflow can push tags via `GITHUB_TOKEN`.
- The `publish-cue` downstream job is preserved untouched and still gated on `needs.release.outputs.full-tag`.

## Testing

After merging, trigger the release workflow via workflow_dispatch or merge a labeled PR.