### PR TITLE
docs: Update license statements

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright 2025 Revanite Incorporated
+   Copyright 2025 Gemara contributors, a Series of LF Projects, LLC.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# SPDX-License-Identifier: Apache-2.0
+
 all: tidy cuefmtcheck lintcue lintinsights gendocs test-links cleanup
 
 #

--- a/auditlog.cue
+++ b/auditlog.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
 package gemara

--- a/capabilitycatalog.cue
+++ b/capabilitycatalog.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("stable")
 package gemara

--- a/cmd/internal/cmd/converter.go
+++ b/cmd/internal/cmd/converter.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/cmd/internal/cmd/cue2openapi.go
+++ b/cmd/internal/cmd/cue2openapi.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/cmd/internal/cmd/lexicon2md.go
+++ b/cmd/internal/cmd/lexicon2md.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/cmd/internal/cmd/openapi2md.go
+++ b/cmd/internal/cmd/openapi2md.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/cmd/internal/cmd/root.go
+++ b/cmd/internal/cmd/root.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/cmd/internal/cmd/termlinker.go
+++ b/cmd/internal/cmd/termlinker.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package cmd
 
 import (

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 package main
 
 import (

--- a/cmd/scripts/parse-nav.sh
+++ b/cmd/scripts/parse-nav.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
 # Parses docs/schema-nav.yml and outputs page information
 # Usage: parse-nav.sh <nav-file> <command>
 # Commands: list-pages, get-title <filename>, get-filename <title>

--- a/cmd/scripts/schema-display-name.sh
+++ b/cmd/scripts/schema-display-name.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+# SPDX-License-Identifier: Apache-2.0
 # Outputs a display title for a schema file base name (e.g. controlcatalog -> "Control Catalog").
 case "$1" in
 base) echo "Base" ;;

--- a/collections.cue
+++ b/collections.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("stable")
 package gemara

--- a/controlcatalog.cue
+++ b/controlcatalog.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("stable")
 package gemara

--- a/docs/assets/js/search.js
+++ b/docs/assets/js/search.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 (function () {
   const input = document.getElementById('search-input');
   const results = document.getElementById('search-results');

--- a/docs/assets/js/theme-toggle.js
+++ b/docs/assets/js/theme-toggle.js
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 /**
  * Theme Toggle Functionality
  * Handles dark/light mode switching with system preference detection and localStorage persistence

--- a/enforcementlog.cue
+++ b/enforcementlog.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
 package gemara

--- a/entities.cue
+++ b/entities.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("stable")
 package gemara

--- a/evaluationlog.cue
+++ b/evaluationlog.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("stable")
 package gemara

--- a/guidancecatalog.cue
+++ b/guidancecatalog.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
 package gemara

--- a/lexicon.cue
+++ b/lexicon.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
 package gemara

--- a/mapping_inline.cue
+++ b/mapping_inline.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("stable")
 

--- a/mappingdocument.cue
+++ b/mappingdocument.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
 package gemara

--- a/metadata.cue
+++ b/metadata.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("stable")
 

--- a/policy.cue
+++ b/policy.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
 package gemara

--- a/principlecatalog.cue
+++ b/principlecatalog.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
 package gemara

--- a/riskcatalog.cue
+++ b/riskcatalog.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
 package gemara

--- a/threatcatalog.cue
+++ b/threatcatalog.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("stable")
 package gemara

--- a/vectorcatalog.cue
+++ b/vectorcatalog.cue
@@ -1,3 +1,5 @@
+// SPDX-License-Identifier: Apache-2.0
+
 // Schema lifecycle: experimental | stable | deprecated
 @status("experimental")
 package gemara


### PR DESCRIPTION
## Description

This updates the license statements to make clear attribution to the Gemara project with Apache 2.0.

## Schema Changes

<!-- REQUIRED: Please disclose any changes made to the schemas -->

### Schema Changes Made

- [x] No schema changes
- [ ] Audit Log schema (`auditlog.cue`) changes
- [ ] Capability Catalog schema (`capabilitycatalog.cue`) changes
- [ ] Control Catalog schema (`controlcatalog.cue`) changes
- [ ] Enforcement Log schema (`enforcementlog.cue`) changes
- [ ] Evaluation Log schema (`evaluationlog.cue`) changes
- [ ] Guidance Catalog schema (`guidancecatalog.cue`) changes
- [ ] Mapping Document schema (`mappingdocument.cue`) changes
- [ ] Policy Document schema (`policy.cue`) changes
- [ ] Principle Catalog schema (`principlecatalog.cue`) changes
- [ ] Risk Catalog schema (`riskcatalog.cue`) changes
- [ ] Threat Catalog schema (`threatcatalog.cue`) changes
- [ ] Vector Catalog schema (`vectorcatalog.cue`) changes
- [ ] Other

 ---

## Self-review checklist

<!-- Maintainer Note: Update the checklist before requesting a review on your PR.-->

- [x] This PR has content that was created with AI assistance. 
   - [x]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [x] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.
