### PR TITLE
ci: update Jekyll workflow Go version to 1.25

### DIFF
--- a/.github/workflows/jekyll-site.yml
+++ b/.github/workflows/jekyll-site.yml
@@ -56,7 +56,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v6
         with:
-          go-version: '1.24'
+          go-version: '1.25'
 
       - name: Generate documentation
         run: make gendocs


### PR DESCRIPTION
## Summary

- Update `go-version` in `jekyll-site.yml` from `1.24` to `1.25` to match `cmd/go.mod` requirement (`go 1.25.0`)

The Go version in `cmd/go.mod` was bumped to `1.25.0` in #431, but the Jekyll
site workflow was not updated. Any PR touching `*.cue` or `docs/**` files now
fails at the `Generate documentation` step because the Go toolchain is too old
to build `cmd/`.

## Related

- Closes #434
- #433 — first PR to hit this failure

## Test plan

- [x] The `build` job in `Jekyll Site CI/CD` should pass after this change
