### PR TITLE
ci: notify the website repo when a release is published

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,14 +52,25 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        id: app-token
+        with:
+          app-id: ${{ secrets.GEMARA_AUTOMATION_CLIENT_ID }}
+          private-key: ${{ secrets.GEMARA_AUTOMATION_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+          repositories: website
+          permission-contents: write
       - name: Trigger website rebuild
+        uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         env:
-          TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
           TAG: ${{ needs.release.outputs.full-tag }}
-        run: |
-          curl -sS --fail -X POST \
-            -H "Authorization: Bearer ${TOKEN}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/gemaraproj/website/dispatches \
-            -d "{\"event_type\":\"gemara-release\",\"client_payload\":{\"ref\":\"${TAG}\"}}"
+        with:
+          github-token: ${{ steps.app-token.outputs.token }}
+          script: |
+            await github.rest.repos.createDispatchEvent({
+              owner: context.repo.owner,
+              repo: 'website',
+              event_type: 'gemara-release',
+              client_payload: { ref: process.env.TAG },
+            });

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         id: app-token
         with:
-          app-id: ${{ secrets.GEMARA_AUTOMATION_CLIENT_ID }}
+          client-id: ${{ secrets.GEMARA_AUTOMATION_CLIENT_ID }}
           private-key: ${{ secrets.GEMARA_AUTOMATION_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: website

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,3 +41,25 @@ jobs:
         run: cue login --token=${{ secrets.CUE_REG_TOKEN }}
       - name: Publish the module
         run: cue mod publish ${{ needs.release.outputs.full-tag }}
+  notify-website:
+    # The website repo regenerates its schema reference pages from the
+    # released spec, so tell it a new release exists. This must happen here
+    # rather than in an `on: release` workflow in the website repo: the
+    # release is created with GITHUB_TOKEN, whose events do not trigger
+    # other workflows.
+    needs: release
+    if: needs.release.outputs.full-tag != ''
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Trigger website rebuild
+        env:
+          TOKEN: ${{ secrets.WEBSITE_DISPATCH_TOKEN }}
+          TAG: ${{ needs.release.outputs.full-tag }}
+        run: |
+          curl -sS --fail -X POST \
+            -H "Authorization: Bearer ${TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/gemaraproj/website/dispatches \
+            -d "{\"event_type\":\"gemara-release\",\"client_payload\":{\"ref\":\"${TAG}\"}}"


### PR DESCRIPTION
## Description

The [new website repo](https://github.com/gemaraproj/website) regenerates its schema reference pages from the released spec. Add a notify-website job to the release workflow that sends a gemara-release repository_dispatch carrying the new tag.

This job lives in release.yml rather than an on:release workflow in the website repo because the release is created with GITHUB_TOKEN, whose events do not trigger downstream workflows (or so Claude tells me; this seemed to be a safe route)

Requires a WEBSITE_DISPATCH_TOKEN secret with permission to send repository_dispatch events to gemaraproj/website, so I've added that in our repo settings.

## Schema Changes

### Schema Changes Made

- [x] No schema changes

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

Relates to #438 - requires a follow-on PR to remove website content from this repo after the live site has been migrated.

## Reviewer Hints

The website also deploys on PR merge to its own codebase. You can see the latest deployment here: https://psychic-winner-8gp1wey.pages.github.io/

## Self-review checklist

- [x] This PR has content that was created with AI assistance. 
   - [x]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [x] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.
