### PR TITLE
ci: publish openapi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,7 @@ jobs:
           ref: ${{ needs.release.outputs.full-tag }}
           persist-credentials: false
       - name: Setup Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
           go-version: '1.25'
       - name: Generate openapi.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,13 +41,41 @@ jobs:
         run: cue login --token=${{ secrets.CUE_REG_TOKEN }}
       - name: Publish the module
         run: cue mod publish ${{ needs.release.outputs.full-tag }}
+  publish-openapi:
+    # The website (and other downstream type generators) consume the spec's
+    # OpenAPI projection, so attach it to the release as an asset.
+    needs: release
+    if: needs.release.outputs.full-tag != ''
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write   # Upload the release asset
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.release.outputs.full-tag }}
+          persist-credentials: false
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.25'
+      - name: Generate openapi.yaml
+        run: make genopenapi
+      - name: Upload release asset
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.release.outputs.full-tag }}
+        run: gh release upload "$TAG" generated/openapi.yaml --clobber
   notify-website:
     # The website repo regenerates its schema reference pages from the
     # released spec, so tell it a new release exists. This must happen here
     # rather than in an `on: release` workflow in the website repo: the
     # release is created with GITHUB_TOKEN, whose events do not trigger
     # other workflows.
-    needs: release
+    #
+    # Runs after publish-openapi so the rebuild finds the openapi.yaml
+    # asset already attached instead of racing the upload.
+    needs: [release, publish-openapi]
     if: needs.release.outputs.full-tag != ''
     runs-on: ubuntu-latest
     permissions: {}


### PR DESCRIPTION
## Description

The website downloads the released OpenAPI projection instead of cloning this repo and generating it, so attach generated/openapi.yaml to each release. notify-website now waits on the upload so the triggered rebuild finds the asset instead of racing it.

## Schema Changes

### Schema Changes Made

- [x] No schema changes
- [ ] Audit Log schema (`auditlog.cue`) changes
- [ ] Capability Catalog schema (`capabilitycatalog.cue`) changes
- [ ] Control Catalog schema (`controlcatalog.cue`) changes
- [ ] Enforcement Log schema (`enforcementlog.cue`) changes
- [ ] Evaluation Log schema (`evaluationlog.cue`) changes
- [ ] Guidance Catalog schema (`guidancecatalog.cue`) changes
- [ ] Mapping Document schema (`mappingdocument.cue`) changes
- [ ] Policy Document schema (`policy.cue`) changes
- [ ] Principle Catalog schema (`principlecatalog.cue`) changes
- [ ] Risk Catalog schema (`riskcatalog.cue`) changes
- [ ] Threat Catalog schema (`threatcatalog.cue`) changes
- [ ] Vector Catalog schema (`vectorcatalog.cue`) changes
- [ ] Other

### Schema Change Details

## Testing

- [ ] Unit tests added/updated
- [ ] Manual testing performed
- [ ] Test data updated (if applicable)

## Related Issues

## Reviewer Hints

## Self-review checklist

- [x] This PR has content that was created with AI assistance. 
   - [x]  I have read and followed the [Generative AI Contribution Policy](https://www.linuxfoundation.org/legal/generative-ai).
- [x] I have the experience and knowledge necessary to answer maintainer questions about the content of this PR, without using AI.
